### PR TITLE
首页侧栏连接文件夹、右键 CRUD 与永驻导航

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ Thumbs.db
 
 # Local-only scripts
 /supabase.sql
+/build.bat
+
+# Local toolchain binaries (do not commit)
+.tools/
 
 # AI Coding 生成的提交文档
 commit-info.md

--- a/crates/ai_chat_view/src/default_panel_tests.rs
+++ b/crates/ai_chat_view/src/default_panel_tests.rs
@@ -151,6 +151,7 @@ fn stored_connection_for_event(id: i64) -> StoredConnection {
         connection_type: ConnectionType::SshSftp,
         params: "{}".to_string(),
         workspace_id: None,
+        folder_id: None,
         selected_databases: None,
         remark: None,
         sync_enabled: true,

--- a/crates/ai_chat_view/src/resource_builder_tests.rs
+++ b/crates/ai_chat_view/src/resource_builder_tests.rs
@@ -22,6 +22,7 @@ fn stored_connection(
         connection_type,
         params: params.to_string(),
         workspace_id: None,
+        folder_id: None,
         selected_databases: None,
         remark: None,
         sync_enabled: true,

--- a/crates/core/migrations/20260717000001_connection_folders.sql
+++ b/crates/core/migrations/20260717000001_connection_folders.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS connection_folders (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    connection_type TEXT NOT NULL,
+    parent_id INTEGER,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    FOREIGN KEY (parent_id) REFERENCES connection_folders(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_connection_folders_type
+    ON connection_folders(connection_type);
+
+CREATE INDEX IF NOT EXISTS idx_connection_folders_parent
+    ON connection_folders(parent_id);
+
+ALTER TABLE connections ADD COLUMN folder_id INTEGER REFERENCES connection_folders(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_connections_folder_id
+    ON connections(folder_id);

--- a/crates/core/src/cloud_sync/conflict.rs
+++ b/crates/core/src/cloud_sync/conflict.rs
@@ -328,6 +328,7 @@ mod tests {
             name: "Test Connection".to_string(),
             connection_type: crate::storage::ConnectionType::Database,
             workspace_id: None,
+            folder_id: None,
             params: "{}".to_string(),
             selected_databases: None,
             remark: None,

--- a/crates/core/src/cloud_sync/connection_sync.rs
+++ b/crates/core/src/cloud_sync/connection_sync.rs
@@ -1225,6 +1225,7 @@ mod tests {
             connection_type: ConnectionType::Database,
             params: "{}".to_string(),
             workspace_id: None,
+            folder_id: None,
             selected_databases: None,
             remark: None,
             sync_enabled: true,

--- a/crates/core/src/cloud_sync/service.rs
+++ b/crates/core/src/cloud_sync/service.rs
@@ -449,6 +449,7 @@ impl CloudSyncService {
                 name: plain_data.name,
                 connection_type,
                 workspace_id: None, // 由调用者根据 workspace_cloud_id 解析
+                folder_id: None,
                 params,
                 selected_databases: plain_data.selected_databases,
                 remark: plain_data.remark,
@@ -580,6 +581,7 @@ mod tests {
             connection_type: ConnectionType::Database,
             params: r#"{"host":"localhost","port":5432}"#.to_string(),
             workspace_id: Some(7),
+            folder_id: None,
             selected_databases: None,
             remark: None,
             sync_enabled: true,

--- a/crates/core/src/storage/migration.rs
+++ b/crates/core/src/storage/migration.rs
@@ -58,6 +58,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "20260714000001",
         include_str!("../../migrations/20260714000001_team_membership_cache.sql"),
     ),
+    (
+        "20260717000001",
+        include_str!("../../migrations/20260717000001_connection_folders.sql"),
+    ),
 ];
 
 pub fn run_migrations(conn: &Connection) -> Result<()> {

--- a/crates/core/src/storage/models.rs
+++ b/crates/core/src/storage/models.rs
@@ -42,7 +42,7 @@ impl ActiveConnections {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ConnectionType {
     All,
     Database,
@@ -893,6 +893,59 @@ impl DbConnectionConfig {
     }
 }
 
+/// Hierarchical folder for organizing connections within a protocol category.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConnectionFolder {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<i64>,
+    pub name: String,
+    /// Protocol category this folder belongs to. Never `ConnectionType::All`.
+    pub connection_type: ConnectionType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort_order: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<i64>,
+}
+
+impl Entity for ConnectionFolder {
+    fn id(&self) -> Option<i64> {
+        self.id
+    }
+
+    fn created_at(&self) -> i64 {
+        self.created_at
+            .expect("created_at 在从数据库读取后应该存在")
+    }
+
+    fn updated_at(&self) -> i64 {
+        self.updated_at
+            .expect("updated_at 在从数据库读取后应该存在")
+    }
+}
+
+impl ConnectionFolder {
+    pub fn new(name: String, connection_type: ConnectionType) -> Self {
+        Self {
+            id: None,
+            name,
+            connection_type,
+            parent_id: None,
+            sort_order: None,
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    pub fn with_parent(mut self, parent_id: Option<i64>) -> Self {
+        self.parent_id = parent_id;
+        self
+    }
+}
+
 /// Workspace for organizing connections
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Workspace {
@@ -990,6 +1043,9 @@ pub struct StoredConnection {
     pub params: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_id: Option<i64>,
+    /// Sidebar folder within the connection's protocol category.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub folder_id: Option<i64>,
     /// 已选中的数据库ID列表（JSON数组），None表示全选
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selected_databases: Option<String>,
@@ -1167,6 +1223,7 @@ impl StoredConnection {
             connection_type: ConnectionType::Database,
             params: serde_json::to_string(&params).expect("DbConnectionConfig 序列化不应失败"),
             workspace_id,
+            folder_id: None,
             selected_databases: if let Some(database) = &params.database {
                 Some(format!("[\"{}\"]", database))
             } else {
@@ -1193,6 +1250,7 @@ impl StoredConnection {
             connection_type: ConnectionType::SshSftp,
             params: serde_json::to_string(&params).expect("SshParams 序列化不应失败"),
             workspace_id,
+            folder_id: None,
             selected_databases: None,
             remark: None,
             sync_enabled: true,
@@ -1219,6 +1277,7 @@ impl StoredConnection {
             connection_type: params.protocol.connection_type(),
             params: serde_json::to_string(&params).expect("RemoteDesktopParams 序列化不应失败"),
             workspace_id,
+            folder_id: None,
             selected_databases: None,
             remark: None,
             sync_enabled: true,
@@ -1241,6 +1300,7 @@ impl StoredConnection {
             connection_type: ConnectionType::Redis,
             params: serde_json::to_string(&params).expect("RedisParams 序列化不应失败"),
             workspace_id,
+            folder_id: None,
             selected_databases: None,
             remark: None,
             sync_enabled: true,
@@ -1263,6 +1323,7 @@ impl StoredConnection {
             connection_type: ConnectionType::MongoDB,
             params: serde_json::to_string(&params).expect("MongoDBParams 序列化不应失败"),
             workspace_id,
+            folder_id: None,
             selected_databases: None,
             remark: None,
             sync_enabled: true,
@@ -1301,6 +1362,7 @@ impl StoredConnection {
             connection_type: ConnectionType::Serial,
             params: serde_json::to_string(&params).expect("SerialParams 序列化不应失败"),
             workspace_id,
+            folder_id: None,
             selected_databases: None,
             remark: None,
             sync_enabled: true,
@@ -1327,6 +1389,7 @@ impl StoredConnection {
             connection_type: ConnectionType::PortForwarding,
             params: serde_json::to_string(&params).expect("PortForwardingParams 序列化不应失败"),
             workspace_id,
+            folder_id: None,
             selected_databases: None,
             remark: None,
             sync_enabled: true,
@@ -1443,6 +1506,7 @@ mod tests {
             service_name: None,
             sid: None,
             workspace_id: Some(7),
+            folder_id: None,
             proxy: None,
             extra_params,
         }
@@ -1555,6 +1619,7 @@ mod tests {
             service_name: None,
             sid: None,
             workspace_id: None,
+            folder_id: None,
             proxy: None,
             extra_params: HashMap::new(),
         };

--- a/crates/core/src/storage/repository.rs
+++ b/crates/core/src/storage/repository.rs
@@ -12,7 +12,7 @@ use crate::storage::team_key_cache::TeamKeyCacheRepository;
 use crate::storage::team_membership_cache::TeamMembershipCacheRepository;
 use crate::storage::terminal_command_history::TerminalCommandHistoryRepository;
 use crate::storage::traits::Repository;
-use crate::storage::{ConnectionType, StoredConnection, Workspace};
+use crate::storage::{ConnectionFolder, ConnectionType, StoredConnection, Workspace};
 
 struct ConnectionRow {
     id: i64,
@@ -20,6 +20,7 @@ struct ConnectionRow {
     connection_type: String,
     params: String,
     workspace_id: Option<i64>,
+    folder_id: Option<i64>,
     selected_databases: Option<String>,
     remark: Option<String>,
     sync_enabled: bool,
@@ -41,6 +42,7 @@ impl FromSqliteRow for ConnectionRow {
             connection_type: row.get("connection_type")?,
             params: row.get("params")?,
             workspace_id: row.get("workspace_id")?,
+            folder_id: row.get("folder_id").unwrap_or(None),
             selected_databases: row.get("selected_databases")?,
             remark: row.get("remark")?,
             sync_enabled: row
@@ -67,6 +69,7 @@ impl From<ConnectionRow> for StoredConnection {
             connection_type: ConnectionType::from_str(&row.connection_type),
             params: row.params,
             workspace_id: row.workspace_id,
+            folder_id: row.folder_id,
             selected_databases: row.selected_databases,
             remark: row.remark,
             sync_enabled: row.sync_enabled,
@@ -162,14 +165,14 @@ impl ConnectionRepository {
                 .optional()?;
             let id = if let Some(id) = existing_id {
                 tx.execute(
-                    "UPDATE connections SET name = ?1, connection_type = ?2, params = ?3, workspace_id = ?4, selected_databases = ?5, remark = ?6, sync_enabled = ?7, cloud_id = ?8, last_synced_at = ?9, team_id = ?10, owner_id = ?11, updated_at = ?12 WHERE id = ?13",
-                    params![item.name, connection_type, encrypted_params, item.workspace_id, item.selected_databases, item.remark, sync_enabled, cloud_id, item.last_synced_at, item.team_id, item.owner_id, ts, id],
+                    "UPDATE connections SET name = ?1, connection_type = ?2, params = ?3, workspace_id = ?4, folder_id = ?5, selected_databases = ?6, remark = ?7, sync_enabled = ?8, cloud_id = ?9, last_synced_at = ?10, team_id = ?11, owner_id = ?12, updated_at = ?13 WHERE id = ?14",
+                    params![item.name, connection_type, encrypted_params, item.workspace_id, item.folder_id, item.selected_databases, item.remark, sync_enabled, cloud_id, item.last_synced_at, item.team_id, item.owner_id, ts, id],
                 )?;
                 id
             } else {
                 tx.execute(
-                    "INSERT INTO connections (name, connection_type, params, workspace_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, team_id, owner_id, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
-                    params![item.name, connection_type, encrypted_params, item.workspace_id, item.selected_databases, item.remark, sync_enabled, cloud_id, item.last_synced_at, item.team_id, item.owner_id, ts, ts],
+                    "INSERT INTO connections (name, connection_type, params, workspace_id, folder_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, team_id, owner_id, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+                    params![item.name, connection_type, encrypted_params, item.workspace_id, item.folder_id, item.selected_databases, item.remark, sync_enabled, cloud_id, item.last_synced_at, item.team_id, item.owner_id, ts, ts],
                 )?;
                 tx.last_insert_rowid()
             };
@@ -195,6 +198,7 @@ impl Repository for ConnectionRepository {
         let connection_type = item.connection_type.to_string();
         let params_str = item.encrypt_params();
         let workspace_id = item.workspace_id;
+        let folder_id = item.folder_id;
         let selected_databases = item.selected_databases.clone();
         let remark = item.remark.clone();
         let sync_enabled = if item.sync_enabled { 1i64 } else { 0i64 };
@@ -206,9 +210,9 @@ impl Repository for ConnectionRepository {
 
         let id = self.conn.with_connection(|conn| {
             conn.execute(
-                "INSERT INTO connections (name, connection_type, params, workspace_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, team_id, owner_id, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
-                params![name, connection_type, params_str, workspace_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, team_id, owner_id, ts, ts],
+                "INSERT INTO connections (name, connection_type, params, workspace_id, folder_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, team_id, owner_id, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+                params![name, connection_type, params_str, workspace_id, folder_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, team_id, owner_id, ts, ts],
             )?;
             Ok(conn.last_insert_rowid())
         })?;
@@ -228,6 +232,7 @@ impl Repository for ConnectionRepository {
         let connection_type = item.connection_type.to_string();
         let params_str = item.encrypt_params();
         let workspace_id = item.workspace_id;
+        let folder_id = item.folder_id;
         let selected_databases = item.selected_databases.clone();
         let remark = item.remark.clone();
         let sync_enabled = if item.sync_enabled { 1i64 } else { 0i64 };
@@ -239,8 +244,8 @@ impl Repository for ConnectionRepository {
 
         self.conn.with_connection(|conn| {
             conn.execute(
-                "UPDATE connections SET name = ?1, connection_type = ?2, params = ?3, workspace_id = ?4, selected_databases = ?5, remark = ?6, sync_enabled = ?7, cloud_id = ?8, last_synced_at = ?9, team_id = ?10, owner_id = ?11, updated_at = ?12 WHERE id = ?13",
-                params![name, connection_type, params_str, workspace_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, team_id, owner_id, ts, id],
+                "UPDATE connections SET name = ?1, connection_type = ?2, params = ?3, workspace_id = ?4, folder_id = ?5, selected_databases = ?6, remark = ?7, sync_enabled = ?8, cloud_id = ?9, last_synced_at = ?10, team_id = ?11, owner_id = ?12, updated_at = ?13 WHERE id = ?14",
+                params![name, connection_type, params_str, workspace_id, folder_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, team_id, owner_id, ts, id],
             )?;
             Ok(())
         })
@@ -256,7 +261,7 @@ impl Repository for ConnectionRepository {
     fn get(&self, id: i64) -> Result<Option<Self::Entity>> {
         self.conn.with_connection(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT id, name, connection_type, params, workspace_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id FROM connections WHERE id = ?1",
+                "SELECT id, name, connection_type, params, workspace_id, folder_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id FROM connections WHERE id = ?1",
             )?;
             let mut rows = stmt.query(params![id])?;
             if let Some(row) = rows.next()? {
@@ -270,7 +275,7 @@ impl Repository for ConnectionRepository {
     fn list(&self) -> Result<Vec<Self::Entity>> {
         self.conn.with_connection(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT id, name, connection_type, params, workspace_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id FROM connections ORDER BY COALESCE(last_used_at, updated_at, created_at) DESC, id DESC",
+                "SELECT id, name, connection_type, params, workspace_id, folder_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id FROM connections ORDER BY COALESCE(last_used_at, updated_at, created_at) DESC, id DESC",
             )?;
             let rows = stmt.query_map([], |row| ConnectionRow::from_row(row))?;
             let mut results = Vec::new();
@@ -305,9 +310,9 @@ impl ConnectionRepository {
     pub fn list_by_workspace(&self, workspace_id: Option<i64>) -> Result<Vec<StoredConnection>> {
         self.conn.with_connection(|conn| {
             let sql = if workspace_id.is_some() {
-                "SELECT id, name, connection_type, params, workspace_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id FROM connections WHERE workspace_id = ?1 ORDER BY COALESCE(last_used_at, updated_at, created_at) DESC, id DESC"
+                "SELECT id, name, connection_type, params, workspace_id, folder_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id FROM connections WHERE workspace_id = ?1 ORDER BY COALESCE(last_used_at, updated_at, created_at) DESC, id DESC"
             } else {
-                "SELECT id, name, connection_type, params, workspace_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id FROM connections WHERE workspace_id IS NULL ORDER BY COALESCE(last_used_at, updated_at, created_at) DESC, id DESC"
+                "SELECT id, name, connection_type, params, workspace_id, folder_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id FROM connections WHERE workspace_id IS NULL ORDER BY COALESCE(last_used_at, updated_at, created_at) DESC, id DESC"
             };
             let mut stmt = conn.prepare(sql)?;
 
@@ -391,7 +396,7 @@ impl ConnectionRepository {
     pub fn list_pending_sync(&self) -> Result<Vec<StoredConnection>> {
         self.conn.with_connection(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT id, name, connection_type, params, workspace_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id
+                "SELECT id, name, connection_type, params, workspace_id, folder_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id
                  FROM connections
                  WHERE sync_enabled = 1 AND (cloud_id IS NULL OR updated_at > COALESCE(last_synced_at, 0))
                  ORDER BY updated_at DESC",
@@ -409,7 +414,7 @@ impl ConnectionRepository {
     pub fn get_by_cloud_id(&self, cloud_id: &str) -> Result<Option<StoredConnection>> {
         self.conn.with_connection(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT id, name, connection_type, params, workspace_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id
+                "SELECT id, name, connection_type, params, workspace_id, folder_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id
                  FROM connections WHERE cloud_id = ?1",
             )?;
             let mut rows = stmt.query(params![cloud_id])?;
@@ -451,7 +456,7 @@ impl ConnectionRepository {
     pub fn list_by_team(&self, team_id: &str) -> Result<Vec<StoredConnection>> {
         self.conn.with_connection(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT id, name, connection_type, params, workspace_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id FROM connections WHERE team_id = ?1 ORDER BY COALESCE(last_used_at, updated_at, created_at) DESC, id DESC",
+                "SELECT id, name, connection_type, params, workspace_id, folder_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id FROM connections WHERE team_id = ?1 ORDER BY COALESCE(last_used_at, updated_at, created_at) DESC, id DESC",
             )?;
             let rows = stmt.query_map(params![team_id], |row| ConnectionRow::from_row(row))?;
             let mut results = Vec::new();
@@ -466,7 +471,7 @@ impl ConnectionRepository {
     pub fn list_personal(&self) -> Result<Vec<StoredConnection>> {
         self.conn.with_connection(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT id, name, connection_type, params, workspace_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id FROM connections WHERE team_id IS NULL ORDER BY COALESCE(last_used_at, updated_at, created_at) DESC, id DESC",
+                "SELECT id, name, connection_type, params, workspace_id, folder_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id FROM connections WHERE team_id IS NULL ORDER BY COALESCE(last_used_at, updated_at, created_at) DESC, id DESC",
             )?;
             let rows = stmt.query_map([], |row| ConnectionRow::from_row(row))?;
             let mut results = Vec::new();
@@ -474,6 +479,310 @@ impl ConnectionRepository {
                 results.push(row?.into());
             }
             Ok(results)
+        })
+    }
+
+    pub fn list_by_folder(&self, folder_id: Option<i64>) -> Result<Vec<StoredConnection>> {
+        self.conn.with_connection(|conn| {
+            let mut results = Vec::new();
+            if let Some(fid) = folder_id {
+                let mut stmt = conn.prepare(
+                    "SELECT id, name, connection_type, params, workspace_id, folder_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id FROM connections WHERE folder_id = ?1 ORDER BY COALESCE(last_used_at, updated_at, created_at) DESC, id DESC",
+                )?;
+                let rows = stmt.query_map(params![fid], |row| ConnectionRow::from_row(row))?;
+                for row in rows {
+                    results.push(row?.into());
+                }
+            } else {
+                let mut stmt = conn.prepare(
+                    "SELECT id, name, connection_type, params, workspace_id, folder_id, selected_databases, remark, sync_enabled, cloud_id, last_synced_at, last_used_at, sort_order, created_at, updated_at, team_id, owner_id FROM connections WHERE folder_id IS NULL ORDER BY COALESCE(last_used_at, updated_at, created_at) DESC, id DESC",
+                )?;
+                let rows = stmt.query_map([], |row| ConnectionRow::from_row(row))?;
+                for row in rows {
+                    results.push(row?.into());
+                }
+            }
+            Ok(results)
+        })
+    }
+
+    pub fn update_folder_id(&self, connection_id: i64, folder_id: Option<i64>) -> Result<()> {
+        let ts = now();
+        self.conn.with_connection(|conn| {
+            conn.execute(
+                "UPDATE connections SET folder_id = ?1, updated_at = ?2 WHERE id = ?3",
+                params![folder_id, ts, connection_id],
+            )?;
+            Ok(())
+        })
+    }
+
+}
+
+
+struct ConnectionFolderRow {
+    id: i64,
+    name: String,
+    connection_type: String,
+    parent_id: Option<i64>,
+    sort_order: Option<i32>,
+    created_at: i64,
+    updated_at: i64,
+}
+
+impl FromSqliteRow for ConnectionFolderRow {
+    fn from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
+        Ok(ConnectionFolderRow {
+            id: row.get("id")?,
+            name: row.get("name")?,
+            connection_type: row.get("connection_type")?,
+            parent_id: row.get("parent_id")?,
+            sort_order: row.get("sort_order").unwrap_or(Some(0)),
+            created_at: row.get("created_at")?,
+            updated_at: row.get("updated_at")?,
+        })
+    }
+}
+
+impl From<ConnectionFolderRow> for ConnectionFolder {
+    fn from(row: ConnectionFolderRow) -> Self {
+        ConnectionFolder {
+            id: Some(row.id),
+            name: row.name,
+            connection_type: ConnectionType::from_str(&row.connection_type),
+            parent_id: row.parent_id,
+            sort_order: row.sort_order,
+            created_at: Some(row.created_at),
+            updated_at: Some(row.updated_at),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ConnectionFolderRepository {
+    conn: SqliteConnection,
+}
+
+impl ConnectionFolderRepository {
+    pub fn new(conn: SqliteConnection) -> Self {
+        Self { conn }
+    }
+
+    pub fn list_by_type(&self, connection_type: ConnectionType) -> Result<Vec<ConnectionFolder>> {
+        let type_str = connection_type.to_string();
+        self.conn.with_connection(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, name, connection_type, parent_id, sort_order, created_at, updated_at
+                 FROM connection_folders
+                 WHERE connection_type = ?1
+                 ORDER BY sort_order ASC, id ASC",
+            )?;
+            let rows = stmt.query_map(params![type_str], |row| ConnectionFolderRow::from_row(row))?;
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row?.into());
+            }
+            Ok(results)
+        })
+    }
+
+    pub fn list_children(&self, parent_id: Option<i64>) -> Result<Vec<ConnectionFolder>> {
+        self.conn.with_connection(|conn| {
+            let mut results = Vec::new();
+            if let Some(pid) = parent_id {
+                let mut stmt = conn.prepare(
+                    "SELECT id, name, connection_type, parent_id, sort_order, created_at, updated_at
+                     FROM connection_folders
+                     WHERE parent_id = ?1
+                     ORDER BY sort_order ASC, id ASC",
+                )?;
+                let rows = stmt.query_map(params![pid], |row| ConnectionFolderRow::from_row(row))?;
+                for row in rows {
+                    results.push(row?.into());
+                }
+            } else {
+                let mut stmt = conn.prepare(
+                    "SELECT id, name, connection_type, parent_id, sort_order, created_at, updated_at
+                     FROM connection_folders
+                     WHERE parent_id IS NULL
+                     ORDER BY sort_order ASC, id ASC",
+                )?;
+                let rows = stmt.query_map([], |row| ConnectionFolderRow::from_row(row))?;
+                for row in rows {
+                    results.push(row?.into());
+                }
+            }
+            Ok(results)
+        })
+    }
+
+    pub fn update_sort_orders(&self, orders: &[(i64, i32)]) -> Result<()> {
+        self.conn.with_connection(|conn| {
+            let tx = conn.unchecked_transaction()?;
+            let ts = now();
+            for (id, sort_order) in orders {
+                tx.execute(
+                    "UPDATE connection_folders SET sort_order = ?1, updated_at = ?2 WHERE id = ?3",
+                    params![sort_order, ts, id],
+                )?;
+            }
+            tx.commit()?;
+            Ok(())
+        })
+    }
+
+    pub fn move_folder(&self, id: i64, new_parent_id: Option<i64>) -> Result<()> {
+        let ts = now();
+        self.conn.with_connection(|conn| {
+            conn.execute(
+                "UPDATE connection_folders SET parent_id = ?1, updated_at = ?2 WHERE id = ?3",
+                params![new_parent_id, ts, id],
+            )?;
+            Ok(())
+        })
+    }
+
+    fn next_sort_order(&self, connection_type: &str, parent_id: Option<i64>) -> Result<i32> {
+        self.conn.with_connection(|conn| {
+            let max_order: Option<i32> = if let Some(pid) = parent_id {
+                conn.query_row(
+                    "SELECT MAX(sort_order) FROM connection_folders WHERE connection_type = ?1 AND parent_id = ?2",
+                    params![connection_type, pid],
+                    |row| row.get(0),
+                )?
+            } else {
+                conn.query_row(
+                    "SELECT MAX(sort_order) FROM connection_folders WHERE connection_type = ?1 AND parent_id IS NULL",
+                    params![connection_type],
+                    |row| row.get(0),
+                )?
+            };
+            Ok(max_order.unwrap_or(-1) + 1)
+        })
+    }
+
+    /// Collect this folder and all descendant folder ids.
+    pub fn collect_descendant_ids(&self, folder_id: i64) -> Result<Vec<i64>> {
+        let all = self.list()?;
+        let mut result = vec![folder_id];
+        let mut queue = vec![folder_id];
+        while let Some(current) = queue.pop() {
+            for folder in &all {
+                if folder.parent_id == Some(current) {
+                    if let Some(id) = folder.id {
+                        result.push(id);
+                        queue.push(id);
+                    }
+                }
+            }
+        }
+        Ok(result)
+    }
+}
+
+impl Repository for ConnectionFolderRepository {
+    type Entity = ConnectionFolder;
+
+    fn entity_type(&self) -> SharedString {
+        SharedString::from("ConnectionFolder")
+    }
+
+    fn insert(&self, item: &mut Self::Entity) -> Result<i64> {
+        let name = item.name.clone();
+        let connection_type = item.connection_type.to_string();
+        let parent_id = item.parent_id;
+        let sort_order = item
+            .sort_order
+            .unwrap_or(self.next_sort_order(&connection_type, parent_id)?);
+        let ts = now();
+
+        let id = self.conn.with_connection(|conn| {
+            conn.execute(
+                "INSERT INTO connection_folders (name, connection_type, parent_id, sort_order, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![name, connection_type, parent_id, sort_order, ts, ts],
+            )?;
+            Ok(conn.last_insert_rowid())
+        })?;
+
+        item.id = Some(id);
+        item.sort_order = Some(sort_order);
+        item.created_at = Some(ts);
+        item.updated_at = Some(ts);
+        Ok(id)
+    }
+
+    fn update(&self, item: &Self::Entity) -> Result<()> {
+        let id = item
+            .id
+            .ok_or_else(|| anyhow::anyhow!("Cannot update without ID"))?;
+        let name = item.name.clone();
+        let connection_type = item.connection_type.to_string();
+        let parent_id = item.parent_id;
+        let sort_order = item.sort_order;
+        let ts = now();
+
+        self.conn.with_connection(|conn| {
+            conn.execute(
+                "UPDATE connection_folders SET name = ?1, connection_type = ?2, parent_id = ?3, sort_order = COALESCE(?4, sort_order), updated_at = ?5 WHERE id = ?6",
+                params![name, connection_type, parent_id, sort_order, ts, id],
+            )?;
+            Ok(())
+        })
+    }
+
+    fn delete(&self, id: i64) -> Result<()> {
+        // ON DELETE CASCADE for child folders; connections.folder_id SET NULL via FK
+        self.conn.with_connection(|conn| {
+            conn.execute("DELETE FROM connection_folders WHERE id = ?1", params![id])?;
+            Ok(())
+        })
+    }
+
+    fn get(&self, id: i64) -> Result<Option<Self::Entity>> {
+        self.conn.with_connection(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, name, connection_type, parent_id, sort_order, created_at, updated_at FROM connection_folders WHERE id = ?1",
+            )?;
+            let mut rows = stmt.query(params![id])?;
+            if let Some(row) = rows.next()? {
+                Ok(Some(ConnectionFolderRow::from_row(row)?.into()))
+            } else {
+                Ok(None)
+            }
+        })
+    }
+
+    fn list(&self) -> Result<Vec<Self::Entity>> {
+        self.conn.with_connection(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, name, connection_type, parent_id, sort_order, created_at, updated_at FROM connection_folders ORDER BY sort_order ASC, id ASC",
+            )?;
+            let rows = stmt.query_map([], |row| ConnectionFolderRow::from_row(row))?;
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row?.into());
+            }
+            Ok(results)
+        })
+    }
+
+    fn count(&self) -> Result<i64> {
+        self.conn.with_connection(|conn| {
+            let count: i64 =
+                conn.query_row("SELECT COUNT(*) FROM connection_folders", [], |row| row.get(0))?;
+            Ok(count)
+        })
+    }
+
+    fn exists(&self, id: i64) -> Result<bool> {
+        self.conn.with_connection(|conn| {
+            let exists: i64 = conn.query_row(
+                "SELECT EXISTS(SELECT 1 FROM connection_folders WHERE id = ?1)",
+                params![id],
+                |row| row.get(0),
+            )?;
+            Ok(exists == 1)
         })
     }
 }
@@ -984,6 +1293,7 @@ pub fn init(cx: &mut App) {
 
     let conn = storage.connection();
     let conn_repo = ConnectionRepository::new(conn.clone());
+    let folder_repo = ConnectionFolderRepository::new(conn.clone());
     let workspace_repo = WorkspaceRepository::new(conn.clone());
     let quick_cmd_repo = QuickCommandRepository::new(conn.clone());
     let sftp_favorite_path_repo = SftpFavoritePathRepository::new(conn.clone());
@@ -998,6 +1308,7 @@ pub fn init(cx: &mut App) {
 
     storage.register(workspace_repo);
     storage.register(conn_repo);
+    storage.register(folder_repo);
     storage.register(quick_cmd_repo);
     storage.register(sftp_favorite_path_repo);
     storage.register(terminal_command_history_repo);

--- a/crates/core/src/storage/sftp_favorite_path.rs
+++ b/crates/core/src/storage/sftp_favorite_path.rs
@@ -291,6 +291,7 @@ mod tests {
             connection_type: ConnectionType::SshSftp,
             params: "{}".to_string(),
             workspace_id: None,
+            folder_id: None,
             selected_databases: None,
             remark: None,
             sync_enabled: true,

--- a/crates/db_view/src/db_tree_view.rs
+++ b/crates/db_view/src/db_tree_view.rs
@@ -3072,6 +3072,7 @@ mod tests {
             connection_type: ConnectionType::Database,
             params: "{}".to_string(),
             workspace_id: None,
+            folder_id: None,
             selected_databases: selected_databases.map(|dbs| {
                 serde_json::to_string(
                     &dbs.into_iter()

--- a/crates/terminal_view/src/sidebar/mod.rs
+++ b/crates/terminal_view/src/sidebar/mod.rs
@@ -1467,6 +1467,7 @@ mod tests {
             connection_type,
             params: "{}".to_string(),
             workspace_id: None,
+            folder_id: None,
             selected_databases: None,
             remark: None,
             sync_enabled: true,

--- a/main/locales/main.yml
+++ b/main/locales/main.yml
@@ -334,6 +334,44 @@ Home:
     en: "%{name} (Copy %{index})"
     zh-CN: "%{name} (副本 %{index})"
     zh-HK: "%{name} (副本 %{index})"
+  new_folder:
+    en: New Folder
+    zh-CN: 新建文件夹
+    zh-HK: 新建資料夾
+  new_subfolder:
+    en: New Subfolder
+    zh-CN: 新建子文件夹
+    zh-HK: 新建子資料夾
+  rename_folder:
+    en: Rename Folder
+    zh-CN: 重命名文件夹
+    zh-HK: 重新命名資料夾
+  delete_folder:
+    en: Delete Folder
+    zh-CN: 删除文件夹
+    zh-HK: 刪除資料夾
+  folder_name_placeholder:
+    en: Folder name
+    zh-CN: 文件夹名称
+    zh-HK: 資料夾名稱
+  delete_folder_confirm:
+    en: "Delete folder \"%{name}\"? Connections inside will become uncategorized."
+    zh-CN: "确定删除文件夹 \"%{name}\" 吗？其中的连接会变为未分类。"
+    zh-HK: "確定刪除資料夾 \"%{name}\" 嗎？其中的連線會變為未分類。"
+  uncategorized:
+    en: Uncategorized
+    zh-CN: 未分类
+    zh-HK: 未分類
+
+Folder:
+  new:
+    en: New Folder
+    zh-CN: 新建文件夹
+    zh-HK: 新建資料夾
+  edit:
+    en: Rename Folder
+    zh-CN: 重命名文件夹
+    zh-HK: 重新命名資料夾
 
 TeamManagement:
   title:

--- a/main/src/home/home_connection_folder.rs
+++ b/main/src/home/home_connection_folder.rs
@@ -1,0 +1,170 @@
+use crate::home_tab::HomePage;
+use gpui::{
+    App, AppContext, Context, Entity, FontWeight, InteractiveElement, IntoElement, ParentElement,
+    Render, Styled, Window, div, px,
+};
+use gpui_component::{
+    ActiveTheme, Icon, IconName, Sizable, Size, WindowExt, h_flex,
+    input::{Input, InputState},
+    v_flex,
+};
+use one_core::storage::ConnectionType;
+use rust_i18n::t;
+
+pub(crate) fn show_folder_dialog(
+    parent: Entity<HomePage>,
+    folder_id: Option<i64>,
+    connection_type: ConnectionType,
+    parent_id: Option<i64>,
+    initial_name: String,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    let name_input = cx.new(|cx| {
+        let mut state = InputState::new(window, cx)
+            .placeholder(t!("Home.folder_name_placeholder"))
+            .clean_on_escape();
+        if !initial_name.is_empty() {
+            state.set_value(initial_name.clone(), window, cx);
+        }
+        state
+    });
+
+    name_input.update(cx, |state, cx| {
+        state.focus(window, cx);
+    });
+
+    let input_for_render = name_input.clone();
+    let input_for_ok = name_input.clone();
+    window.open_dialog(cx, move |dialog, _window, _cx| {
+        let parent_for_ok = parent.clone();
+        let input_for_ok = input_for_ok.clone();
+        dialog
+            .title(
+                if folder_id.is_some() {
+                    t!("Folder.edit").to_string()
+                } else {
+                    t!("Folder.new").to_string()
+                }
+                .into_any_element(),
+            )
+            .child(
+                v_flex()
+                    .gap_3()
+                    .w(px(360.0))
+                    .child(Input::new(&input_for_render).w_full()),
+            )
+            .confirm()
+            .on_ok(move |_, _, cx| {
+                let name = input_for_ok.read(cx).text().to_string().trim().to_string();
+                if name.is_empty() {
+                    return false;
+                }
+                let _ = parent_for_ok.update(cx, |home, cx| {
+                    home.handle_save_folder(folder_id, name, connection_type, parent_id, cx);
+                });
+                true
+            })
+    });
+}
+
+#[derive(Clone)]
+pub(crate) struct DragConnectionFolder {
+    pub source_id: i64,
+    pub name: String,
+    pub connection_type: ConnectionType,
+    pub parent_id: Option<i64>,
+}
+
+impl Render for DragConnectionFolder {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        h_flex()
+            .id("drag-connection-folder")
+            .cursor_grabbing()
+            .w(px(220.0))
+            .px_3()
+            .py_2()
+            .items_center()
+            .gap_2()
+            .rounded(px(6.0))
+            .border_1()
+            .border_color(cx.theme().border)
+            .bg(cx.theme().popover)
+            .shadow_md()
+            .child(Icon::new(IconName::Folder).with_size(Size::Small))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .text_sm()
+                    .font_weight(FontWeight::MEDIUM)
+                    .overflow_hidden()
+                    .text_ellipsis()
+                    .whitespace_nowrap()
+                    .child(self.name.clone()),
+            )
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DragSidebarConnection {
+    pub connection_id: i64,
+    pub name: String,
+    pub connection_type: ConnectionType,
+}
+
+impl Render for DragSidebarConnection {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        h_flex()
+            .id("drag-sidebar-connection")
+            .cursor_grabbing()
+            .w(px(220.0))
+            .px_3()
+            .py_2()
+            .items_center()
+            .gap_2()
+            .rounded(px(6.0))
+            .border_1()
+            .border_color(cx.theme().border)
+            .bg(cx.theme().popover)
+            .shadow_md()
+            .child(Icon::new(self.connection_type.icon()).with_size(Size::Small))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .text_sm()
+                    .overflow_hidden()
+                    .text_ellipsis()
+                    .whitespace_nowrap()
+                    .child(self.name.clone()),
+            )
+    }
+}
+
+pub(crate) fn confirm_delete_folder(
+    parent: Entity<HomePage>,
+    folder_id: i64,
+    folder_name: String,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    window.open_dialog(cx, move |dialog, _window, _cx| {
+        let parent_for_ok = parent.clone();
+        dialog
+            .title(t!("Home.delete_folder").to_string().into_any_element())
+            .child(
+                div()
+                    .w(px(360.0))
+                    .text_sm()
+                    .child(t!("Home.delete_folder_confirm", name = folder_name).to_string()),
+            )
+            .confirm()
+            .on_ok(move |_, _, cx| {
+                let _ = parent_for_ok.update(cx, |home, cx| {
+                    home.handle_delete_folder(folder_id, cx);
+                });
+                true
+            })
+    });
+}

--- a/main/src/home/mod.rs
+++ b/main/src/home/mod.rs
@@ -10,6 +10,7 @@ mod connection_import_model_tests;
 pub(crate) mod connection_import_window;
 #[cfg(test)]
 mod connection_import_window_tests;
+pub(crate) mod home_connection_folder;
 pub(crate) mod home_connection_quick_open;
 pub(crate) mod home_strategy;
 pub(crate) mod home_tabs;

--- a/main/src/home_tab.rs
+++ b/main/src/home_tab.rs
@@ -18,7 +18,9 @@ use gpui_component::{
     h_flex,
     input::{Input, InputEvent, InputState},
     list::{List, ListState},
+    menu::{ContextMenuExt, PopupMenuItem},
     popover::Popover,
+    scroll::ScrollableElement,
     tooltip::Tooltip,
     v_flex,
 };
@@ -39,10 +41,10 @@ use one_core::popup_window::{PopupWindowOptions, open_popup_window};
 use one_core::settings::{AppSettings, SyncProvider};
 use one_core::storage::traits::Repository;
 use one_core::storage::{
-    ActiveConnections, ConnectionRepository, ConnectionType, DatabaseType, GlobalStorageState,
-    PendingCloudDeletionRepository, RedisMode, RemoteDesktopParams,
-    RemoteDesktopProtocol as StoredRemoteDesktopProtocol, StoredConnection, TeamMembershipState,
-    Workspace, WorkspaceRepository,
+    ActiveConnections, ConnectionFolder, ConnectionFolderRepository, ConnectionRepository,
+    ConnectionType, DatabaseType, GlobalStorageState, PendingCloudDeletionRepository, RedisMode,
+    RemoteDesktopParams, RemoteDesktopProtocol as StoredRemoteDesktopProtocol, StoredConnection,
+    TeamMembershipState, Workspace, WorkspaceRepository,
 };
 use one_core::tab_container::{TabContainer, TabContent, TabContentEvent, TabItem, TabOpenMode};
 use port_forwarding::PortForwardingRuntime;
@@ -58,6 +60,9 @@ use terminal_view::{SshFormWindow, SshFormWindowConfig};
 use crate::auth::{AuthService, load_auth_data, show_auth_dialog};
 use crate::external_driver_display::external_driver_icon_for_config_with_registry;
 use crate::home::connection_import_window::show_connection_import_window;
+use crate::home::home_connection_folder::{
+    DragConnectionFolder, DragSidebarConnection, confirm_delete_folder, show_folder_dialog,
+};
 use crate::home::home_connection_quick_open::ConnectionQuickOpenDelegate;
 use crate::home::home_strategy::build_connection_open_strategy;
 use crate::home::home_workspace_filter::{WorkspaceFilterDelegate, show_workspace_dialog};
@@ -81,6 +86,8 @@ actions!(
 
 const HOME_SIDEBAR_EXPANDED_WIDTH: gpui::Pixels = px(220.0);
 const HOME_SIDEBAR_COLLAPSED_WIDTH: gpui::Pixels = px(68.0);
+/// 与 TabContainer::render_tab_bar 的高度保持一致，避免左右顶栏错位。
+const HOME_SIDEBAR_HEADER_HEIGHT: gpui::Pixels = px(40.0);
 const HOME_CONNECTION_LIST_ACTIONS_WIDTH: gpui::Pixels = px(136.0);
 const OPEN_LOCAL_TERMINAL_SHORTCUT_MACOS: &str = "cmd-alt-t";
 const OPEN_LOCAL_TERMINAL_SHORTCUT_OTHER: &str = "alt-t";
@@ -236,9 +243,14 @@ impl ConnectionLayout {
 pub struct HomePage {
     focus_handle: FocusHandle,
     selected_filter: ConnectionType,
+    /// 侧栏选中的文件夹；有值时右侧仅显示该文件夹及其子孙下的连接。
+    selected_folder_id: Option<i64>,
     connection_layout: ConnectionLayout,
     pub(crate) workspaces: Vec<Workspace>,
     pub(crate) connections: Vec<StoredConnection>,
+    pub(crate) connection_folders: Vec<ConnectionFolder>,
+    expanded_categories: HashSet<ConnectionType>,
+    expanded_folders: HashSet<i64>,
     pub(crate) tab_container: Entity<TabContainer>,
     search_input: Entity<InputState>,
     search_query: Entity<String>,
@@ -811,9 +823,13 @@ impl HomePage {
         let mut page = Self {
             focus_handle: cx.focus_handle(),
             selected_filter: ConnectionType::All,
+            selected_folder_id: None,
             connection_layout: ConnectionLayout::Card,
             workspaces: Vec::new(),
             connections: Vec::new(),
+            connection_folders: Vec::new(),
+            expanded_categories: HashSet::new(),
+            expanded_folders: HashSet::new(),
             tab_container,
             search_input,
             search_query,
@@ -843,8 +859,9 @@ impl HomePage {
             external_driver_registry: IpcDriverRegistry::empty(),
         };
 
-        // 异步加载工作区
+        // 异步加载工作区与文件夹
         page.load_workspaces(cx);
+        page.load_connection_folders(cx);
 
         // 尝试从存储后端恢复主密钥
         let key_restored = crypto::try_restore_master_key();
@@ -998,6 +1015,295 @@ impl HomePage {
             }
         })
         .detach();
+    }
+
+    fn load_connection_folders(&mut self, cx: &mut Context<Self>) {
+        let storage = cx.global::<GlobalStorageState>().storage.clone();
+        let load_task = cx.background_spawn(async move {
+            (|| {
+                let repo = storage
+                    .get::<ConnectionFolderRepository>()
+                    .ok_or_else(|| anyhow::anyhow!("ConnectionFolderRepository not found"))?;
+                Ok::<_, anyhow::Error>(repo.list()?)
+            })()
+        });
+
+        cx.spawn(async move |this, cx: &mut AsyncApp| {
+            match load_task.await {
+                Ok(folders) => {
+                    _ = this.update(cx, |this, cx| {
+                        this.connection_folders = folders;
+                        cx.notify();
+                    });
+                }
+                Err(e) => {
+                    tracing::error!("加载连接文件夹失败: {}", e);
+                }
+            }
+        })
+        .detach();
+    }
+
+    fn folder_descendant_ids(&self, folder_id: i64) -> HashSet<i64> {
+        let mut result = HashSet::from([folder_id]);
+        let mut queue = vec![folder_id];
+        while let Some(current) = queue.pop() {
+            for folder in &self.connection_folders {
+                if folder.parent_id == Some(current) {
+                    if let Some(id) = folder.id {
+                        if result.insert(id) {
+                            queue.push(id);
+                        }
+                    }
+                }
+            }
+        }
+        result
+    }
+
+    fn toggle_category_expanded(&mut self, connection_type: ConnectionType, cx: &mut Context<Self>) {
+        if self.expanded_categories.contains(&connection_type) {
+            self.expanded_categories.remove(&connection_type);
+        } else {
+            self.expanded_categories.insert(connection_type);
+        }
+        cx.notify();
+    }
+
+    fn toggle_folder_expanded(&mut self, folder_id: i64, cx: &mut Context<Self>) {
+        if self.expanded_folders.contains(&folder_id) {
+            self.expanded_folders.remove(&folder_id);
+        } else {
+            self.expanded_folders.insert(folder_id);
+        }
+        cx.notify();
+    }
+
+    fn select_category_filter(
+        &mut self,
+        connection_type: ConnectionType,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.selected_filter = connection_type;
+        self.selected_folder_id = None;
+        self.expanded_categories.insert(connection_type);
+        self.activate_home_tab(window, cx);
+        cx.notify();
+    }
+
+    fn select_folder_filter(
+        &mut self,
+        connection_type: ConnectionType,
+        folder_id: i64,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.selected_filter = connection_type;
+        self.selected_folder_id = Some(folder_id);
+        self.expanded_categories.insert(connection_type);
+        self.expanded_folders.insert(folder_id);
+        self.activate_home_tab(window, cx);
+        cx.notify();
+    }
+
+    pub(crate) fn handle_save_folder(
+        &mut self,
+        folder_id: Option<i64>,
+        name: String,
+        connection_type: ConnectionType,
+        parent_id: Option<i64>,
+        cx: &mut Context<Self>,
+    ) {
+        let storage = cx.global::<GlobalStorageState>().storage.clone();
+        let name = name.trim().to_string();
+        if name.is_empty() {
+            return;
+        }
+
+        let result: anyhow::Result<()> = (|| {
+            let repo = storage
+                .get::<ConnectionFolderRepository>()
+                .ok_or_else(|| anyhow::anyhow!("ConnectionFolderRepository not found"))?;
+            if let Some(id) = folder_id {
+                let mut folder = repo
+                    .get(id)?
+                    .ok_or_else(|| anyhow::anyhow!("folder not found"))?;
+                folder.name = name;
+                folder.connection_type = connection_type;
+                folder.parent_id = parent_id;
+                repo.update(&folder)?;
+            } else {
+                let mut folder =
+                    ConnectionFolder::new(name, connection_type).with_parent(parent_id);
+                repo.insert(&mut folder)?;
+            }
+            Ok(())
+        })();
+
+        if let Err(err) = result {
+            tracing::error!("保存连接文件夹失败: {err}");
+            return;
+        }
+        self.load_connection_folders(cx);
+        cx.notify();
+    }
+
+    pub(crate) fn handle_delete_folder(&mut self, folder_id: i64, cx: &mut Context<Self>) {
+        let storage = cx.global::<GlobalStorageState>().storage.clone();
+        let result: anyhow::Result<()> = (|| {
+            let repo = storage
+                .get::<ConnectionFolderRepository>()
+                .ok_or_else(|| anyhow::anyhow!("ConnectionFolderRepository not found"))?;
+            repo.delete(folder_id)?;
+            Ok(())
+        })();
+
+        if let Err(err) = result {
+            tracing::error!("删除连接文件夹失败: {err}");
+            return;
+        }
+        if self.selected_folder_id == Some(folder_id) {
+            self.selected_folder_id = None;
+        }
+        self.expanded_folders.remove(&folder_id);
+        self.load_connection_folders(cx);
+        self.load_connections(cx);
+        cx.notify();
+    }
+
+    pub(crate) fn reorder_folder_by_id(
+        &mut self,
+        source_id: i64,
+        target_id: i64,
+        cx: &mut Context<Self>,
+    ) {
+        if source_id == target_id {
+            return;
+        }
+        let Some(source) = self
+            .connection_folders
+            .iter()
+            .find(|f| f.id == Some(source_id))
+            .cloned()
+        else {
+            return;
+        };
+        let Some(target) = self
+            .connection_folders
+            .iter()
+            .find(|f| f.id == Some(target_id))
+            .cloned()
+        else {
+            return;
+        };
+        // 仅允许同协议、同父级内排序
+        if source.connection_type != target.connection_type || source.parent_id != target.parent_id
+        {
+            return;
+        }
+
+        let mut siblings: Vec<_> = self
+            .connection_folders
+            .iter()
+            .filter(|f| {
+                f.connection_type == source.connection_type && f.parent_id == source.parent_id
+            })
+            .cloned()
+            .collect();
+        siblings.sort_by_key(|f| (f.sort_order.unwrap_or(0), f.id.unwrap_or(0)));
+
+        let Some(from_idx) = siblings.iter().position(|f| f.id == Some(source_id)) else {
+            return;
+        };
+        let Some(to_idx) = siblings.iter().position(|f| f.id == Some(target_id)) else {
+            return;
+        };
+        let item = siblings.remove(from_idx);
+        siblings.insert(to_idx, item);
+
+        let orders: Vec<(i64, i32)> = siblings
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, f)| f.id.map(|id| (id, idx as i32)))
+            .collect();
+
+        let storage = cx.global::<GlobalStorageState>().storage.clone();
+        let result: anyhow::Result<()> = (|| {
+            let repo = storage
+                .get::<ConnectionFolderRepository>()
+                .ok_or_else(|| anyhow::anyhow!("ConnectionFolderRepository not found"))?;
+            repo.update_sort_orders(&orders)?;
+            Ok(())
+        })();
+        if let Err(err) = result {
+            tracing::error!("文件夹排序失败: {err}");
+            return;
+        }
+        self.load_connection_folders(cx);
+    }
+
+    pub(crate) fn move_connection_to_folder(
+        &mut self,
+        connection_id: i64,
+        folder_id: Option<i64>,
+        cx: &mut Context<Self>,
+    ) {
+        let storage = cx.global::<GlobalStorageState>().storage.clone();
+        let result: anyhow::Result<()> = (|| {
+            let repo = storage
+                .get::<ConnectionRepository>()
+                .ok_or_else(|| anyhow::anyhow!("ConnectionRepository not found"))?;
+            repo.update_folder_id(connection_id, folder_id)?;
+            Ok(())
+        })();
+        if let Err(err) = result {
+            tracing::error!("移动连接到文件夹失败: {err}");
+            return;
+        }
+        self.load_connections(cx);
+    }
+
+    pub(crate) fn move_folder_to_parent(
+        &mut self,
+        folder_id: i64,
+        new_parent_id: Option<i64>,
+        cx: &mut Context<Self>,
+    ) {
+        // 禁止把自己拖进子孙节点
+        if let Some(parent_id) = new_parent_id {
+            if self.folder_descendant_ids(folder_id).contains(&parent_id) {
+                return;
+            }
+        }
+        let storage = cx.global::<GlobalStorageState>().storage.clone();
+        let result: anyhow::Result<()> = (|| {
+            let repo = storage
+                .get::<ConnectionFolderRepository>()
+                .ok_or_else(|| anyhow::anyhow!("ConnectionFolderRepository not found"))?;
+            // 保持协议一致
+            if let Some(parent_id) = new_parent_id {
+                let parent = repo
+                    .get(parent_id)?
+                    .ok_or_else(|| anyhow::anyhow!("parent folder not found"))?;
+                let mut folder = repo
+                    .get(folder_id)?
+                    .ok_or_else(|| anyhow::anyhow!("folder not found"))?;
+                if folder.connection_type != parent.connection_type {
+                    return Ok(());
+                }
+                folder.parent_id = Some(parent_id);
+                repo.update(&folder)?;
+            } else {
+                repo.move_folder(folder_id, None)?;
+            }
+            Ok(())
+        })();
+        if let Err(err) = result {
+            tracing::error!("移动文件夹失败: {err}");
+            return;
+        }
+        self.load_connection_folders(cx);
     }
 
     fn load_team_options(&mut self, cx: &mut Context<Self>) {
@@ -1493,6 +1799,87 @@ impl HomePage {
             self.editing_connection_id = Some(conn_id);
             self.show_connection_form(db_type, window, cx);
         }
+    }
+
+    fn edit_connection_by_id(
+        &mut self,
+        conn_id: i64,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(conn) = self.connections.iter().find(|c| c.id == Some(conn_id)).cloned() else {
+            return;
+        };
+        match conn.connection_type {
+            ConnectionType::SshSftp => {
+                self.editing_connection_id = Some(conn_id);
+                self.show_ssh_form(window, cx);
+            }
+            ConnectionType::Database => {
+                let db_type = conn.to_db_connection().ok().map(|p| p.database_type);
+                self.confirm_edit_connection(conn_id, conn.name.clone(), db_type, window, cx);
+            }
+            ConnectionType::Redis => {
+                self.editing_connection_id = Some(conn_id);
+                self.show_redis_form(window, cx);
+            }
+            ConnectionType::MongoDB => {
+                self.editing_connection_id = Some(conn_id);
+                self.show_mongodb_form(window, cx);
+            }
+            ConnectionType::Serial => {
+                self.editing_connection_id = Some(conn_id);
+                self.show_serial_form(window, cx);
+            }
+            ConnectionType::PortForwarding => {
+                self.editing_connection_id = Some(conn_id);
+                self.show_port_forwarding_form(window, cx);
+            }
+            ConnectionType::Rdp => {
+                self.editing_connection_id = Some(conn_id);
+                self.show_remote_desktop_form(StoredRemoteDesktopProtocol::Rdp, window, cx);
+            }
+            ConnectionType::Vnc => {
+                self.editing_connection_id = Some(conn_id);
+                self.show_remote_desktop_form(StoredRemoteDesktopProtocol::Vnc, window, cx);
+            }
+            ConnectionType::All => {}
+        }
+    }
+
+    fn start_new_connection_for_type(
+        &mut self,
+        connection_type: ConnectionType,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.editing_connection_id = None;
+        match connection_type {
+            ConnectionType::All => self.show_new_connection_dialog(window, cx),
+            ConnectionType::Database => self.show_new_connection_dialog(window, cx),
+            ConnectionType::SshSftp => self.show_ssh_form(window, cx),
+            ConnectionType::Redis => self.show_redis_form(window, cx),
+            ConnectionType::MongoDB => self.show_mongodb_form(window, cx),
+            ConnectionType::Serial => self.show_serial_form(window, cx),
+            ConnectionType::PortForwarding => self.show_port_forwarding_form(window, cx),
+            ConnectionType::Rdp => {
+                self.show_remote_desktop_form(StoredRemoteDesktopProtocol::Rdp, window, cx)
+            }
+            ConnectionType::Vnc => {
+                self.show_remote_desktop_form(StoredRemoteDesktopProtocol::Vnc, window, cx)
+            }
+        }
+    }
+
+    fn activate_home_tab(&self, window: &mut Window, cx: &mut Context<Self>) {
+        // 延迟激活：当前可能正处于 HomePage update 中（侧栏点击），
+        // TabContainer 激活时会 read HomePage 的 focus_handle，同步调用会双重租约 panic。
+        let tab_container = self.tab_container.clone();
+        window.defer(cx, move |window, cx| {
+            tab_container.update(cx, |tabs, cx| {
+                tabs.activate_pinned_tab_at(0, window, cx);
+            });
+        });
     }
 
     /// 复制连接，创建一个副本
@@ -3073,7 +3460,621 @@ impl HomePage {
         cx.notify();
     }
 
-    fn render_sidebar(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_sidebar_category(
+        &self,
+        filter_type: ConnectionType,
+        collapsed: bool,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let is_selected =
+            self.selected_filter == filter_type && self.selected_folder_id.is_none();
+        let is_expanded = filter_type == ConnectionType::All
+            || self.expanded_categories.contains(&filter_type);
+        let can_expand = filter_type != ConnectionType::All;
+        let category_count = self
+            .connections
+            .iter()
+            .filter(|c| {
+                filter_type == ConnectionType::All || c.connection_type == filter_type
+            })
+            .count();
+
+        let view = cx.entity();
+        let drag_border_color = cx.theme().drag_border;
+        let header = div()
+            .id(SharedString::from(format!("sidebar-cat-{}", filter_type)))
+            .flex()
+            .items_center()
+            .gap_2()
+            .w_full()
+            .when(collapsed, |this| this.justify_center().px_0())
+            .when(!collapsed, |this| this.px_2())
+            .py_1p5()
+            .cursor_pointer()
+            .rounded_lg()
+            .overflow_hidden()
+            .when(is_selected, |this| {
+                this.bg(cx.theme().list_active)
+                    .border_l_3()
+                    .border_color(cx.theme().list_active_border)
+            })
+            .when(!is_selected, |this| {
+                this.bg(cx.theme().sidebar)
+                    .hover(|style| style.bg(cx.theme().sidebar_accent))
+            })
+            // 拖到分类标题 = 移出文件夹，回到该分类根级
+            .drag_over::<DragSidebarConnection>(move |this, drag, _, _| {
+                if drag.connection_type == filter_type || filter_type == ConnectionType::All {
+                    this.border_1().border_color(drag_border_color)
+                } else {
+                    this
+                }
+            })
+            .on_drop(cx.listener(
+                move |this, drag: &DragSidebarConnection, _window, cx| {
+                    if drag.connection_type == filter_type || filter_type == ConnectionType::All {
+                        this.move_connection_to_folder(drag.connection_id, None, cx);
+                    }
+                },
+            ))
+            .on_click(cx.listener(move |this: &mut HomePage, _, window, cx| {
+                this.select_category_filter(filter_type, window, cx);
+                if can_expand && !this.expanded_categories.contains(&filter_type) {
+                    this.expanded_categories.insert(filter_type);
+                    cx.notify();
+                }
+            }))
+            .context_menu({
+                let view = view.clone();
+                move |menu, window, _cx| {
+                    let view_for_new_conn = view.clone();
+                    let view_for_new_folder = view.clone();
+                    let mut menu = menu.item(
+                        PopupMenuItem::new(t!("Home.new_connection").to_string()).on_click(
+                            window.listener_for(&view_for_new_conn, move |this, _, window, cx| {
+                                this.expanded_categories.insert(filter_type);
+                                this.start_new_connection_for_type(filter_type, window, cx);
+                            }),
+                        ),
+                    );
+                    if can_expand {
+                        menu = menu.item(
+                            PopupMenuItem::new(t!("Home.new_folder").to_string()).on_click(
+                                window.listener_for(
+                                    &view_for_new_folder,
+                                    move |this, _, window, cx| {
+                                        this.select_category_filter(filter_type, window, cx);
+                                        this.expanded_categories.insert(filter_type);
+                                        show_folder_dialog(
+                                            cx.entity(),
+                                            None,
+                                            filter_type,
+                                            None,
+                                            String::new(),
+                                            window,
+                                            cx,
+                                        );
+                                    },
+                                ),
+                            ),
+                        );
+                    }
+                    menu
+                }
+            })
+            .when(!collapsed && can_expand, |this| {
+                this.child(
+                    div()
+                        .id(SharedString::from(format!("sidebar-cat-toggle-{}", filter_type)))
+                        .on_click(cx.listener(move |this: &mut HomePage, _, _window, cx| {
+                            cx.stop_propagation();
+                            this.toggle_category_expanded(filter_type, cx);
+                        }))
+                        .child(
+                            Icon::new(if is_expanded {
+                                IconName::ChevronDown
+                            } else {
+                                IconName::ChevronRight
+                            })
+                            .with_size(Size::Small)
+                            .text_color(cx.theme().muted_foreground),
+                        ),
+                )
+            })
+            .child(Icon::new(filter_type.icon()).color().with_size(Size::Large))
+            .when(!collapsed, |this| {
+                this.child(
+                    div()
+                        .flex_1()
+                        .min_w_0()
+                        .text_sm()
+                        .text_color(cx.theme().foreground)
+                        .when(is_selected, |this| this.font_weight(FontWeight::MEDIUM))
+                        .overflow_hidden()
+                        .text_ellipsis()
+                        .whitespace_nowrap()
+                        .child(filter_type.label()),
+                )
+                .child(
+                    div()
+                        .text_xs()
+                        .text_color(cx.theme().muted_foreground)
+                        .child(format!("{category_count}")),
+                )
+            });
+
+        let mut container = v_flex().w_full().gap_0p5().child(header);
+
+        if !collapsed && can_expand && is_expanded {
+            let mut root_folders: Vec<_> = self
+                .connection_folders
+                .iter()
+                .filter(|f| f.connection_type == filter_type && f.parent_id.is_none())
+                .cloned()
+                .collect();
+            root_folders.sort_by_key(|f| (f.sort_order.unwrap_or(0), f.id.unwrap_or(0)));
+            let root_connections: Vec<_> = self
+                .connections
+                .iter()
+                .filter(|c| c.connection_type == filter_type && c.folder_id.is_none())
+                .cloned()
+                .collect();
+
+            // 根级投放区：把连接拖到这里也会移出文件夹
+            let mut root_drop = v_flex()
+                .id(SharedString::from(format!("sidebar-cat-root-{}", filter_type)))
+                .w_full()
+                .min_h(px(8.0))
+                .gap_0p5()
+                .drag_over::<DragSidebarConnection>(move |this, drag, _, _| {
+                    if drag.connection_type == filter_type {
+                        this.rounded(px(6.0))
+                            .border_1()
+                            .border_color(drag_border_color)
+                    } else {
+                        this
+                    }
+                })
+                .on_drop(cx.listener(
+                    move |this, drag: &DragSidebarConnection, _window, cx| {
+                        if drag.connection_type == filter_type {
+                            this.move_connection_to_folder(drag.connection_id, None, cx);
+                        }
+                    },
+                ));
+
+            for folder in root_folders {
+                root_drop = root_drop.child(self.render_sidebar_folder(
+                    folder,
+                    filter_type,
+                    1,
+                    cx,
+                ));
+            }
+            for conn in root_connections {
+                root_drop =
+                    root_drop.child(self.render_sidebar_connection(conn, filter_type, 1, cx));
+            }
+            container = container.child(root_drop);
+        }
+
+        container.into_any_element()
+    }
+
+    fn render_sidebar_folder(
+        &self,
+        folder: one_core::storage::ConnectionFolder,
+        connection_type: ConnectionType,
+        depth: usize,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let folder_id = folder.id.unwrap_or(0);
+        let is_selected = self.selected_folder_id == Some(folder_id);
+        let is_expanded = self.expanded_folders.contains(&folder_id);
+        let mut child_folders: Vec<_> = self
+            .connection_folders
+            .iter()
+            .filter(|f| f.parent_id == Some(folder_id))
+            .cloned()
+            .collect();
+        child_folders.sort_by_key(|f| (f.sort_order.unwrap_or(0), f.id.unwrap_or(0)));
+        let child_connections: Vec<_> = self
+            .connections
+            .iter()
+            .filter(|c| c.folder_id == Some(folder_id))
+            .cloned()
+            .collect();
+        let indent = px(8.0 + depth as f32 * 12.0);
+        let drag_border_color = cx.theme().drag_border;
+        let folder_name = folder.name.clone();
+        let folder_parent = folder.parent_id;
+
+        let view = cx.entity();
+        let rename_name = folder.name.clone();
+        let rename_parent = folder.parent_id;
+        let delete_name = folder.name.clone();
+        let header = h_flex()
+            .id(SharedString::from(format!("sidebar-folder-{folder_id}")))
+            .w_full()
+            .items_center()
+            .gap_1()
+            .pl(indent)
+            .pr_1()
+            .py_1()
+            .cursor_pointer()
+            .rounded(px(6.0))
+            .when(is_selected, |this| {
+                this.bg(cx.theme().list_active)
+                    .border_l_2()
+                    .border_color(cx.theme().list_active_border)
+            })
+            .when(!is_selected, |this| {
+                this.hover(|style| style.bg(cx.theme().sidebar_accent))
+            })
+            .drag_over::<DragConnectionFolder>(move |this, drag, _, _| {
+                if drag.source_id != folder_id {
+                    this.border_1().border_color(drag_border_color)
+                } else {
+                    this
+                }
+            })
+            .drag_over::<DragSidebarConnection>(move |this, _, _, _| {
+                this.border_1().border_color(drag_border_color)
+            })
+            .on_drop(cx.listener(
+                move |this, drag: &DragConnectionFolder, _window, cx| {
+                    if drag.source_id == folder_id {
+                        return;
+                    }
+                    if drag.connection_type != connection_type {
+                        return;
+                    }
+                    // 同父级：排序；否则移动为子文件夹
+                    if drag.parent_id == folder_parent {
+                        this.reorder_folder_by_id(drag.source_id, folder_id, cx);
+                    } else {
+                        this.move_folder_to_parent(drag.source_id, Some(folder_id), cx);
+                    }
+                },
+            ))
+            .on_drop(cx.listener(
+                move |this, drag: &DragSidebarConnection, _window, cx| {
+                    if drag.connection_type == connection_type {
+                        this.move_connection_to_folder(drag.connection_id, Some(folder_id), cx);
+                    }
+                },
+            ))
+            .on_click(cx.listener(move |this: &mut HomePage, _, window, cx| {
+                this.select_folder_filter(connection_type, folder_id, window, cx);
+            }))
+            .on_drag(
+                DragConnectionFolder {
+                    source_id: folder_id,
+                    name: folder_name.clone(),
+                    connection_type,
+                    parent_id: folder_parent,
+                },
+                |drag, _, _, cx| {
+                    cx.stop_propagation();
+                    cx.new(|_| drag.clone())
+                },
+            )
+            .context_menu({
+                let view = view.clone();
+                move |menu, window, _cx| {
+                    let view_new_conn = view.clone();
+                    let view_new_folder = view.clone();
+                    let view_rename = view.clone();
+                    let view_delete = view.clone();
+                    let rename_name = rename_name.clone();
+                    let delete_name = delete_name.clone();
+                    menu.item(
+                        PopupMenuItem::new(t!("Home.new_connection").to_string()).on_click(
+                            window.listener_for(&view_new_conn, move |this, _, window, cx| {
+                                this.expanded_folders.insert(folder_id);
+                                this.start_new_connection_for_type(connection_type, window, cx);
+                            }),
+                        ),
+                    )
+                    .item(
+                        PopupMenuItem::new(t!("Home.new_subfolder").to_string()).on_click(
+                            window.listener_for(&view_new_folder, move |this, _, window, cx| {
+                                this.expanded_folders.insert(folder_id);
+                                show_folder_dialog(
+                                    cx.entity(),
+                                    None,
+                                    connection_type,
+                                    Some(folder_id),
+                                    String::new(),
+                                    window,
+                                    cx,
+                                );
+                            }),
+                        ),
+                    )
+                    .separator()
+                    .item(
+                        PopupMenuItem::new(t!("Home.rename_folder").to_string()).on_click(
+                            window.listener_for(&view_rename, move |_this, _, window, cx| {
+                                show_folder_dialog(
+                                    cx.entity(),
+                                    Some(folder_id),
+                                    connection_type,
+                                    rename_parent,
+                                    rename_name.clone(),
+                                    window,
+                                    cx,
+                                );
+                            }),
+                        ),
+                    )
+                    .item(
+                        PopupMenuItem::new(t!("Home.delete_folder").to_string()).on_click(
+                            window.listener_for(&view_delete, move |_this, _, window, cx| {
+                                confirm_delete_folder(
+                                    cx.entity(),
+                                    folder_id,
+                                    delete_name.clone(),
+                                    window,
+                                    cx,
+                                );
+                            }),
+                        ),
+                    )
+                }
+            })
+            .child(
+                div()
+                    .id(SharedString::from(format!("sidebar-folder-toggle-{folder_id}")))
+                    .on_click(cx.listener(move |this: &mut HomePage, _, _window, cx| {
+                        cx.stop_propagation();
+                        this.toggle_folder_expanded(folder_id, cx);
+                    }))
+                    .child(
+                        Icon::new(if is_expanded {
+                            IconName::ChevronDown
+                        } else {
+                            IconName::ChevronRight
+                        })
+                        .with_size(Size::XSmall)
+                        .text_color(cx.theme().muted_foreground),
+                    ),
+            )
+            .child(
+                Icon::new(if is_expanded {
+                    IconName::FolderOpen
+                } else {
+                    IconName::Folder
+                })
+                .with_size(Size::Small)
+                .text_color(cx.theme().muted_foreground),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .text_sm()
+                    .overflow_hidden()
+                    .text_ellipsis()
+                    .whitespace_nowrap()
+                    .when(is_selected, |this| this.font_weight(FontWeight::MEDIUM))
+                    .child(folder.name.clone()),
+            );
+
+        let mut container = v_flex().w_full().gap_0p5().child(header);
+        if is_expanded {
+            for child in child_folders {
+                container = container.child(self.render_sidebar_folder(
+                    child,
+                    connection_type,
+                    depth + 1,
+                    cx,
+                ));
+            }
+            for conn in child_connections {
+                container = container.child(self.render_sidebar_connection(
+                    conn,
+                    connection_type,
+                    depth + 1,
+                    cx,
+                ));
+            }
+        }
+        container.into_any_element()
+    }
+
+    fn render_sidebar_connection(
+        &self,
+        conn: StoredConnection,
+        connection_type: ConnectionType,
+        depth: usize,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let conn_id = conn.id.unwrap_or(0);
+        let is_selected = self.selected_connection_id == Some(conn_id);
+        let indent = px(8.0 + depth as f32 * 12.0);
+        let name = conn.name.clone();
+        let can_edit = can_edit_connection_with_cached_teams(
+            conn.team_id.as_deref(),
+            &self.team_options,
+            self.current_user.is_some(),
+        );
+        let is_ssh = matches!(connection_type, ConnectionType::SshSftp);
+        let view = cx.entity();
+        let delete_name = name.clone();
+
+        div()
+            .id(SharedString::from(format!("sidebar-conn-{conn_id}")))
+            .flex()
+            .items_center()
+            .gap_2()
+            .w_full()
+            .pl(indent)
+            .pr_2()
+            .py_1()
+            .cursor_pointer()
+            .rounded(px(6.0))
+            .when(is_selected, |this| this.bg(cx.theme().list_active))
+            .when(!is_selected, |this| {
+                this.hover(|style| style.bg(cx.theme().sidebar_accent))
+            })
+            .on_drag(
+                DragSidebarConnection {
+                    connection_id: conn_id,
+                    name: name.clone(),
+                    connection_type,
+                },
+                |drag, _, _, cx| {
+                    cx.stop_propagation();
+                    cx.new(|_| drag.clone())
+                },
+            )
+            .on_click(cx.listener(move |this: &mut HomePage, _, window, cx| {
+                if let Some(connection) = this.connections.iter().find(|c| c.id == Some(conn_id)) {
+                    let connection = connection.clone();
+                    this.selected_connection_id = Some(conn_id);
+                    this.open_connection_from_quick(&connection, window, cx);
+                }
+            }))
+            .context_menu({
+                let view = view.clone();
+                move |menu, window, _cx| {
+                    let view_open = view.clone();
+                    let view_sftp = view.clone();
+                    let view_edit = view.clone();
+                    let view_dup = view.clone();
+                    let view_del = view.clone();
+                    let delete_name = delete_name.clone();
+
+                    let mut menu = menu.item(
+                        PopupMenuItem::new(t!("Home.open_connection").to_string()).on_click(
+                            window.listener_for(&view_open, move |this, _, window, cx| {
+                                if let Some(connection) =
+                                    this.connections.iter().find(|c| c.id == Some(conn_id))
+                                {
+                                    let connection = connection.clone();
+                                    this.selected_connection_id = Some(conn_id);
+                                    this.open_connection_from_quick(&connection, window, cx);
+                                }
+                            }),
+                        ),
+                    );
+
+                    if is_ssh {
+                        menu = menu.item(
+                            PopupMenuItem::new(t!("Home.open_sftp").to_string()).on_click(
+                                window.listener_for(&view_sftp, move |this, _, window, cx| {
+                                    if let Some(connection) =
+                                        this.connections.iter().find(|c| c.id == Some(conn_id))
+                                    {
+                                        let connection = connection.clone();
+                                        this.open_sftp_view(connection, window, cx);
+                                    }
+                                }),
+                            ),
+                        );
+                    }
+
+                    menu = menu
+                        .separator()
+                        .item(
+                            PopupMenuItem::new(t!("Home.edit_connection").to_string())
+                                .disabled(!can_edit)
+                                .on_click(window.listener_for(
+                                    &view_edit,
+                                    move |this, _, window, cx| {
+                                        this.edit_connection_by_id(conn_id, window, cx);
+                                    },
+                                )),
+                        )
+                        .item(
+                            PopupMenuItem::new(t!("Home.duplicate_connection").to_string())
+                                .on_click(window.listener_for(
+                                    &view_dup,
+                                    move |this, _, window, cx| {
+                                        if let Some(connection) =
+                                            this.connections.iter().find(|c| c.id == Some(conn_id))
+                                        {
+                                            let connection = connection.clone();
+                                            this.duplicate_connection(connection, window, cx);
+                                        }
+                                    },
+                                )),
+                        )
+                        .item(
+                            PopupMenuItem::new(t!("Home.delete_connection").to_string())
+                                .disabled(!can_edit)
+                                .on_click(window.listener_for(
+                                    &view_del,
+                                    move |this, _, window, cx| {
+                                        this.confirm_delete_connection(
+                                            conn_id,
+                                            delete_name.clone(),
+                                            window,
+                                            cx,
+                                        );
+                                    },
+                                )),
+                        );
+
+                    menu
+                }
+            })
+            .child(self.sidebar_connection_icon(&conn, connection_type, cx))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .text_sm()
+                    .overflow_hidden()
+                    .text_ellipsis()
+                    .whitespace_nowrap()
+                    .child(name),
+            )
+            .into_any_element()
+    }
+
+    /// 侧栏连接图标：数据库用驱动彩色图标，SSH 用线框终端 prompt，其它类型与列表一致走 `.color()`。
+    fn sidebar_connection_icon(
+        &self,
+        conn: &StoredConnection,
+        connection_type: ConnectionType,
+        _cx: &mut Context<Self>,
+    ) -> AnyElement {
+        match connection_type {
+            ConnectionType::Database => conn
+                .to_db_connection()
+                .map(|config| {
+                    external_driver_icon_for_config_with_registry(
+                        &config,
+                        Size::Small,
+                        &self.external_driver_registry,
+                    )
+                    .unwrap_or_else(|| config.database_type.as_icon())
+                })
+                .unwrap_or_else(|_| Icon::new(ConnectionType::Database.icon()).color())
+                .with_size(Size::Small)
+                .flex_shrink_0()
+                .into_any_element(),
+            // 线框终端 + `>`，对齐用户期望的 prompt 风格
+            ConnectionType::SshSftp => Icon::new(IconName::SquareTerminal)
+                .text_color(gpui::rgb(0x8b5cf6))
+                .with_size(Size::Small)
+                .flex_shrink_0()
+                .into_any_element(),
+            _ => Icon::new(connection_type.icon())
+                .color()
+                .with_size(Size::Small)
+                .flex_shrink_0()
+                .into_any_element(),
+        }
+    }
+
+    pub(crate) fn render_sidebar(
+        &mut self,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
         // 同步全局用户状态：如果设置页面执行了登出，同步清空本地状态
         let global_user = GlobalCurrentUser::get_user(cx);
         if global_user.is_none() && self.current_user.is_some() {
@@ -3097,68 +4098,66 @@ impl HomePage {
             .h_full()
             .flex_shrink_0()
             .bg(cx.theme().sidebar)
-            .border_r_1()
-            .border_color(cx.theme().border)
             .child(
-                // 侧边栏过滤选项
+                // 顶部品牌栏：与右侧 tab 栏同色，右侧不画浅色边，避免白缝
+                h_flex()
+                    .id("sidebar-brand-header")
+                    .w_full()
+                    .h(HOME_SIDEBAR_HEADER_HEIGHT)
+                    .flex_shrink_0()
+                    .items_center()
+                    .justify_center()
+                    .bg(gpui::rgb(0x2b2b2b))
+                    .border_b_1()
+                    .border_color(gpui::rgb(0x1e1e1e))
+                    .when(collapsed, |this| {
+                        this.child(
+                            Icon::new(IconName::LayoutDashboard)
+                                .with_size(Size::Small)
+                                .text_color(gpui::white()),
+                        )
+                    })
+                    .when(!collapsed, |this| {
+                        this.child(
+                            div()
+                                .text_base()
+                                .font_weight(FontWeight::BOLD)
+                                .text_color(gpui::white())
+                                .child("Navop"),
+                        )
+                    }),
+            )
+            .child(
+                // 内容区（分类树 + 底部操作）保留右侧分隔线
                 v_flex()
                     .flex_1()
                     .w_full()
-                    .p_2()
-                    .gap_2()
-                    .when(collapsed, |this| this.items_center())
-                    .children(filter_types.into_iter().map(|filter_type| {
-                        let is_selected = self.selected_filter == filter_type;
-                        let filter_type_clone = filter_type;
-
-                        div()
-                            .id(filter_type.label())
-                            .flex()
-                            .items_center()
-                            .gap_3()
-                            .w_full()
-                            .when(collapsed, |this| this.justify_center().px_0())
-                            .when(!collapsed, |this| this.px_3())
-                            .py_2()
-                            .cursor_pointer()
-                            .rounded_lg()
-                            .overflow_hidden()
-                            .when(is_selected, |this| {
-                                this.bg(cx.theme().list_active)
-                                    .border_l_3()
-                                    .border_color(cx.theme().list_active_border)
-                            })
-                            .when(!is_selected, |this| {
-                                this.bg(cx.theme().sidebar)
-                                    .hover(|style| style.bg(cx.theme().sidebar_accent))
-                            })
-                            .on_click(cx.listener(move |this: &mut HomePage, _, _window, cx| {
-                                this.selected_filter = filter_type_clone;
-                                cx.notify();
-                            }))
-                            .child(Icon::new(filter_type.icon()).color().with_size(Size::Large))
-                            .when(!collapsed, |this| {
-                                this.child(
-                                    div()
-                                        .text_sm()
-                                        .text_color(cx.theme().foreground)
-                                        .when(is_selected, |this| {
-                                            this.font_weight(FontWeight::MEDIUM)
-                                        })
-                                        .child(filter_type.label()),
-                                )
-                            })
-                    })),
-            )
-            .child(
-                // 底部区域：主题切换、设置和用户头像
-                v_flex()
-                    .w_full()
-                    .when(collapsed, |this| this.items_center().p_2())
-                    .when(!collapsed, |this| this.p_4())
-                    .gap_3()
-                    .border_t_1()
+                    .min_h_0()
+                    .border_r_1()
                     .border_color(cx.theme().border)
+                    .child(
+                        // 侧边栏：协议分类 + 文件夹树
+                        v_flex()
+                            .flex_1()
+                            .w_full()
+                            .min_h_0()
+                            .p_2()
+                            .gap_1()
+                            .overflow_y_scrollbar()
+                            .when(collapsed, |this| this.items_center())
+                            .children(filter_types.into_iter().map(|filter_type| {
+                                self.render_sidebar_category(filter_type, collapsed, cx)
+                            })),
+                    )
+                    .child(
+                        // 底部区域：主题切换、设置和用户头像
+                        v_flex()
+                            .w_full()
+                            .when(collapsed, |this| this.items_center().p_2())
+                            .when(!collapsed, |this| this.p_4())
+                            .gap_3()
+                            .border_t_1()
+                            .border_color(cx.theme().border)
                     .when(show_team_management_entry, |this| {
                         this.child(
                             Button::new("open_team_management")
@@ -3259,32 +4258,24 @@ impl HomePage {
                                 ))
                             })
                     }),
+            ),
             )
             .child(
+                // 全高定位层仅用于垂直居中，点击事件只挂在按钮上
                 div()
                     .absolute()
                     .right_0()
                     .top_0()
                     .bottom_0()
-                    .w(px(24.0))
+                    .w(px(18.0))
                     .flex()
                     .items_center()
                     .justify_center()
-                    .occlude()
-                    .cursor_pointer()
-                    .on_mouse_down(
-                        gpui::MouseButton::Left,
-                        cx.listener(|this, _, window, cx| {
-                            window.prevent_default();
-                            cx.stop_propagation();
-                            this.toggle_sidebar(cx);
-                        }),
-                    )
                     .child(
                         div()
                             .id("home-sidebar-toggle")
                             .w(px(18.0))
-                            .h(px(52.0))
+                            .h(px(72.0))
                             .flex()
                             .items_center()
                             .justify_center()
@@ -3293,7 +4284,17 @@ impl HomePage {
                             .border_color(cx.theme().border)
                             .bg(cx.theme().background)
                             .shadow_sm()
+                            .cursor_pointer()
+                            .occlude()
                             .hover(|this| this.bg(cx.theme().muted))
+                            .on_mouse_down(
+                                gpui::MouseButton::Left,
+                                cx.listener(|this, _, window, cx| {
+                                    window.prevent_default();
+                                    cx.stop_propagation();
+                                    this.toggle_sidebar(cx);
+                                }),
+                            )
                             .child(
                                 Icon::new(if collapsed {
                                     IconName::ChevronRight
@@ -3308,9 +4309,20 @@ impl HomePage {
     }
 
     fn match_connection_type(&self, conn: &StoredConnection) -> bool {
-        match self.selected_filter {
+        let type_matched = match self.selected_filter {
             ConnectionType::All => true,
             filter_type => conn.connection_type == filter_type,
+        };
+        if !type_matched {
+            return false;
+        }
+        if let Some(folder_id) = self.selected_folder_id {
+            let allowed = self.folder_descendant_ids(folder_id);
+            conn.folder_id
+                .map(|id| allowed.contains(&id))
+                .unwrap_or(false)
+        } else {
+            true
         }
     }
 
@@ -4884,34 +5896,21 @@ impl Render for HomePage {
             });
         }
 
-        div()
+        // 侧栏已提升到 OnetCliApp 层永驻；首页只渲染右侧内容区。
+        v_flex()
             .size_full()
             .min_w_0()
             .track_focus(&self.focus_handle)
+            .bg(cx.theme().background)
+            .child(self.render_toolbar(window, cx))
             .child(
-                h_flex()
-                    .size_full()
+                div()
+                    .flex_1()
+                    .w_full()
                     .min_w_0()
                     .overflow_hidden()
-                    .child(self.render_sidebar(window, cx))
-                    .child(
-                        v_flex()
-                            .flex_1()
-                            .min_w_0()
-                            .h_full()
-                            .overflow_hidden()
-                            .bg(cx.theme().background)
-                            .child(self.render_toolbar(window, cx))
-                            .child(
-                                div()
-                                    .flex_1()
-                                    .w_full()
-                                    .min_w_0()
-                                    .overflow_hidden()
-                                    .bg(cx.theme().muted)
-                                    .child(self.render_content_area(cx)),
-                            ),
-                    ),
+                    .bg(cx.theme().muted)
+                    .child(self.render_content_area(cx)),
             )
     }
 }

--- a/main/src/onetcli_app.rs
+++ b/main/src/onetcli_app.rs
@@ -5,7 +5,9 @@ use gpui::{
     App, AppContext, Context, Entity, IntoElement, KeyBinding, Keystroke, ParentElement, Render,
     Styled, Window, actions, div,
 };
-use gpui_component::{WindowExt, dialog::DialogButtonProps, kbd::Kbd, notification::Notification};
+use gpui_component::{
+    WindowExt, dialog::DialogButtonProps, h_flex, kbd::Kbd, notification::Notification,
+};
 use one_core::keybindings::{action_id, rebind_keybindings, shortcuts_for};
 use raw_window_handle::HasWindowHandle;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
@@ -1336,11 +1338,35 @@ impl Render for OnetCliApp {
         let dialog_layer = Root::render_dialog_layer(window, cx);
         let notification_layer = Root::render_notification_layer(window, cx);
 
+        // 左侧连接侧栏永驻：不随 Home tab 切换而消失。
+        let home_page = cx
+            .try_global::<GlobalHomePage>()
+            .map(|g| g.home_page.clone());
+        let permanent_sidebar = home_page.map(|home| {
+            home.update(cx, |home, cx| {
+                home.render_sidebar(window, cx).into_any_element()
+            })
+        });
+
         div()
             .size_full()
             .relative()
             .bg(cx.theme().background)
-            .child(div().size_full().child(self.tab_container.clone()))
+            .child(
+                h_flex()
+                    .size_full()
+                    .min_w_0()
+                    .overflow_hidden()
+                    .children(permanent_sidebar)
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .h_full()
+                            .overflow_hidden()
+                            .child(self.tab_container.clone()),
+                    ),
+            )
             .children(sheet_layer)
             .children(dialog_layer)
             .children(notification_layer)

--- a/main/src/public_mcp_runtime/resource_pool.rs
+++ b/main/src/public_mcp_runtime/resource_pool.rs
@@ -368,6 +368,7 @@ mod tests {
             connection_type,
             params: params.to_string(),
             workspace_id: None,
+            folder_id: None,
             selected_databases: None,
             remark: None,
             sync_enabled: true,

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,90 @@
+@echo off
+setlocal EnableExtensions
+
+rem Navop run-from-source script
+rem Usage:
+rem   run.bat
+rem   run.bat --release
+rem   run.bat -- <args>
+
+cd /d "%~dp0"
+if errorlevel 1 (
+    echo [ERROR] Failed to change directory to project root: %~dp0
+    exit /b 1
+)
+
+where cargo >nul 2>nul
+if errorlevel 1 (
+    echo [ERROR] cargo not found. Install Rust and add cargo to PATH.
+    echo         https://rustup.rs
+    exit /b 1
+)
+
+where rustup >nul 2>nul
+if not errorlevel 1 (
+    if exist "%CD%\rust-toolchain.toml" (
+        echo [info] Ensuring project toolchain from rust-toolchain.toml ...
+        rustup show active-toolchain
+        if errorlevel 1 (
+            echo [ERROR] Failed to activate project toolchain.
+            echo         Try: rustup install 1.95.0
+            exit /b 1
+        )
+    )
+)
+
+set "RELEASE_FLAG="
+set "APP_ARGS="
+
+:parse_args
+if "%~1"=="" goto run
+if /I "%~1"=="--release" (
+    set "RELEASE_FLAG=--release"
+    shift
+    goto parse_args
+)
+if "%~1"=="--" (
+    shift
+    goto collect_app_args
+)
+set "APP_ARGS=%APP_ARGS% %1"
+shift
+goto parse_args
+
+:collect_app_args
+if "%~1"=="" goto run
+set "APP_ARGS=%APP_ARGS% %1"
+shift
+goto collect_app_args
+
+:run
+echo ========================================
+echo  Run Navop from source
+echo  Dir: %CD%
+if defined RELEASE_FLAG (
+    echo  Mode: release
+) else (
+    echo  Mode: debug
+)
+echo ========================================
+echo.
+
+if defined RELEASE_FLAG (
+    cargo run -p main --release --%APP_ARGS%
+) else (
+    cargo run -p main --%APP_ARGS%
+)
+
+set "EXIT_CODE=%ERRORLEVEL%"
+if not "%EXIT_CODE%"=="0" (
+    echo.
+    echo [FAILED] Exit code: %EXIT_CODE%
+    echo.
+    echo If the error mentions cold_path or E0658, your Rust is too old.
+    echo This project needs Rust 1.95.0+.
+    echo   rustup install 1.95.0
+    echo   rustup show
+    exit /b %EXIT_CODE%
+)
+
+exit /b 0

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+profile = "minimal"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
新功能描述
1.重构首页左侧侧栏：分类可展开、多级连接文件夹与拖拽、
2.右键增删改查；SSH 打开后侧栏永驻；品牌栏与顶栏配色对齐；
3.修复白缝、收缩按钮命中区、分类点击 panic；支持连接拖出文件夹
4.并优化侧栏连接图标。同步补充 Windows 运行/编译脚本与构建依赖。
截图/演示
<img width="530" height="557" alt="image" src="https://github.com/user-attachments/assets/7f52e38d-bb97-432b-b1d4-8195aab307ff" />
<img width="765" height="574" alt="image" src="https://github.com/user-attachments/assets/cfbcb6db-e3c6-441f-b1ac-ec53e546fa5e" />
