### PR TITLE
feat(rdp): windows-native-rdp 默认进入 main 构建

### DIFF
--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -81,7 +81,7 @@ gpui = { workspace = true, features = ["test-support"] }
 tempfile = "3"
 
 [features]
-default = ["wasm-components", "embedded-webview"]
+default = ["wasm-components", "embedded-webview", "windows-native-rdp"]
 api-testing = ["dep:api_tools"]
 builtin-duckdb = ["db/builtin-duckdb", "db_view/builtin-duckdb", "onetcli_runtime/builtin-duckdb"]
 builtin-redis = ["redis_view/builtin-redis", "onetcli_runtime/builtin-redis"]

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -781,7 +781,7 @@ mod native_driver_feature_contract_tests {
     }
 
     #[test]
-    fn windows_native_rdp_feature_is_declared_and_default_off() {
+    fn windows_native_rdp_feature_is_declared_and_enabled_by_default() {
         let main_manifest = include_str!("../Cargo.toml");
         let remote_desktop_view_manifest =
             include_str!("../../crates/remote_desktop_view/Cargo.toml");
@@ -800,7 +800,10 @@ mod native_driver_feature_contract_tests {
             main_features
                 .contains("windows-native-rdp = [\"remote_desktop_view/windows-native-rdp\"]")
         );
-        assert!(!main_default.contains("windows-native-rdp"));
+        assert!(
+            main_default.contains("windows-native-rdp"),
+            "the Windows native RDP backend must be part of the default build"
+        );
         assert!(
             remote_desktop_view_features.contains(
                 "windows-native-rdp = [\"dep:raw-window-handle\", \"dep:windows_rdp_host\"]"


### PR DESCRIPTION
- main 默认 feature 加入 windows-native-rdp，普通 cargo build/run 即包含原生 RDP 后端
- 非 Windows 平台仍以 windows_rdp_host stub 模式编译，native 代码保持 target_os=windows 门控
- 契约测试同步改为断言默认启用

Closes #[issue number]

## Description

Describe in English for the changes made in this pull request and the problem it solves.
Please keep **1 PR to solve 1 problem**, and keep **Small improvements should be small modifications** to make PR easier to review and to merge.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| [Put Before Screenshot here] | [Put After Screenshot here] |

## Break Changes

Describe any breaking changes introduced by this pull request. If none, remove this section.

- Change 1

```diff
- Old code snippet
+ New code snippet
```

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
