### PR TITLE
fix(windows-native-rdp): 用 _dupenv_s 替代弃用的 getenv，消除 /W4 /WX 下 C4996 …

### DIFF
--- a/crates/windows_rdp_host/native/diagnostic.cpp
+++ b/crates/windows_rdp_host/native/diagnostic.cpp
@@ -14,8 +14,18 @@ constexpr char kReplacementCharacter[] = "\xEF\xBF\xBD";
 // operation does not flood stderr; set `NAVOP_REMOTE_DESKTOP_DIAGNOSTICS`
 // (the same switch as the Rust-side remote desktop diagnostics) to re-enable.
 bool native_trace_enabled() noexcept {
-    static const bool enabled =
-        std::getenv("NAVOP_REMOTE_DESKTOP_DIAGNOSTICS") != nullptr;
+    static const bool enabled = []() noexcept {
+        char* value = nullptr;
+        const errno_t error = _dupenv_s(
+            &value,
+            nullptr,
+            "NAVOP_REMOTE_DESKTOP_DIAGNOSTICS");
+        if (error != 0 || value == nullptr) {
+            return false;
+        }
+        std::free(value);
+        return true;
+    }();
     return enabled;
 }
 


### PR DESCRIPTION
…编译错误

Closes #[issue number]

## Description

Describe in English for the changes made in this pull request and the problem it solves.
Please keep **1 PR to solve 1 problem**, and keep **Small improvements should be small modifications** to make PR easier to review and to merge.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| [Put Before Screenshot here] | [Put After Screenshot here] |

## Break Changes

Describe any breaking changes introduced by this pull request. If none, remove this section.

- Change 1

```diff
- Old code snippet
+ New code snippet
```

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
