### PR TITLE
feat(ssh): add opt-in compatibility support for old SSH servers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -471,6 +471,13 @@
 - **验证方式**：纯 contract 覆盖搜索自动展开、显式折叠优先、非搜索态遵循普通展开状态；真实树测试确认搜索中箭头可反复收起/展开，修改搜索词后重新自动展示匹配路径，清空搜索后保留用户最后的普通展开选择。
 - **适用范围**：`crates/redis_view/src/redis_tree_view.rs`，以及数据库树、文件树、资源树等同时支持过滤和层级展开的 GPUI 树视图。
 
+- **标题**：旧 SSH 服务器的 DH 协商失败通常是超出 russh gex 位宽下限而非缺少算法
+- **触发信号**：legacy 兼容算法已开启且 `No common Key/Mac algorithm` 已消失，但连接仍失败；日志出现 `russh::client::kex: DH prime size (2048 bits) not within requested range` 或 `(1024 bits) not within requested range` 后跟 `Key exchange init failed`。用 `ssh -o KexAlgorithms=xxx` 探测可拿到服务器真实 offer 列表。
+- **根因 / 约束**：russh `GexParams` 默认 `min_group_size=3072`，客户端配置校验也强制不低于 2048。2048 位组（老 Cisco/网管）可用 `GexParams::new(2048, 2048, 8192)` 放行；但更旧设备只提供 1024 位组时，GEX 路径无论如何都过不了 2048 下限。这类设备通常除 `group-exchange-sha1` 外还声明**固定组** `diffie-hellman-group1-sha1`（固定 1024 位组不走 GEX 范围校验），而 russh 客户端按自身列表顺序选 kex，一旦 `DH_GEX_SHA1` 排在 `DH_G1_SHA1` 前就会优先走进 GEX 死路。`Key exchange init failed` 是 `Error::KexInit` 而非 `NoCommonAlgo`，`add_legacy_algorithm_hint` 不会附加提示。
+- **正确做法**：在 `build_russh_client_config` 内按 `allow_legacy_algorithms` 选 `gex`：legacy 用 `client::GexParams::new(2048, 2048, 8192)`，现代路径保持默认；同时把 legacy KEX 顺序固定为现代组 → `DH_G14_SHA1` → `DH_G1_SHA1` → `DH_GEX_SHA1`，让 1024 位设备优先走固定 group1 路径，GEX 只作为最后回退。用具名常量避免魔法数字；真实 offer 探测 `ssh -o BatchMode=yes -o PreferredAuthentications=none -o KexAlgorithms=...` 区分“无共同算法”与“只有 1024 位组”。
+- **验证方式**：`cargo check -p ssh`、`cargo test -p ssh`（覆盖 gex 参数开/关、固定 group1 排在 group-exchange 前、以及 fake server 只声明 `DH_GEX_SHA1 + DH_G1_SHA1` 且 `lookup_dh_gex_group` 固定返回 `DH_GROUP1` 时 legacy 开启连接成功、关闭时报 `No common Kex algorithm`）、`cargo clippy -p ssh --all-targets` 无新增警告；再用真机 DMG 分别连接 2048 位组与 1024 位组设备确认 `Key exchange init failed` 消失。
+- **适用范围**：`crates/ssh/src/ssh.rs::build_russh_client_config` / `legacy_gex_params` / `build_client_preferred_algorithms_with_legacy`，以及任何直接构造 `russh::client::Config` 的 legacy 兼容链路。
+
 ### 执行原则
 
 1. 先澄清，再实现；先缩小边界，再扩展范围。

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,7 @@ llm-connector = { version = "1.4.0", features = ["streaming"] }
 redis_client = { package = "redis", version = "0.27", features = ["tokio-comp", "cluster-async", "connection-manager"] }
 
 # SSH and SFTP
+# dsa feature enables verifying/offering the legacy ssh-dss host-key algorithm.
 russh = { version = "0.62.4", features = ["dsa"] }
 russh-sftp = "2.3.0"
 tokio-socks = "0.5"

--- a/crates/ssh/locales/ssh.yml
+++ b/crates/ssh/locales/ssh.yml
@@ -62,6 +62,6 @@ Ssh:
     zh-CN: "HTTP代理连接失败: %{response}"
     zh-HK: "HTTP代理連線失敗: %{response}"
   legacy_algorithms_required_hint:
-    en: The server may only support legacy SSH key-exchange or host-key algorithms. Edit this connection and enable “Allow Legacy SSH Algorithms” under “Advanced Settings”, then try again.
-    zh-CN: 服务器可能仅支持旧版 SSH 密钥交换或主机密钥算法。请编辑此连接，在“高级设置”中开启“允许旧版 SSH 算法”后重试。
-    zh-HK: 伺服器可能僅支援舊版 SSH 金鑰交換或主機金鑰演算法。請編輯此連線，在「進階設定」中開啟「允許舊版 SSH 演算法」後重試。
+    en: The server may only support legacy SSH algorithms, for example a DSA host key, SHA-1 key exchange, or SHA-1 MAC. Edit this connection and enable “Allow Legacy SSH Algorithms” under “Advanced Settings”, then try again.
+    zh-CN: 服务器可能仅支持旧版 SSH 算法，例如 DSA 主机密钥、SHA-1 密钥交换或 SHA-1 MAC。请编辑此连接，在“高级设置”中开启“允许旧版 SSH 算法”后重试。
+    zh-HK: 伺服器可能僅支援舊版 SSH 演算法，例如 DSA 主機金鑰、SHA-1 金鑰交換或 SHA-1 MAC。請編輯此連線，在「進階設定」中開啟「允許舊版 SSH 演算法」後重試。

--- a/crates/ssh/src/connection_error.rs
+++ b/crates/ssh/src/connection_error.rs
@@ -19,13 +19,15 @@ impl fmt::Display for LegacyAlgorithmRequired {
 
 impl StdError for LegacyAlgorithmRequired {}
 
-/// Add an actionable hint only when russh reports a legacy KEX or DSA host-key
-/// negotiation failure and this connection has not enabled legacy algorithms.
+/// Add an actionable hint when russh reports that no common legacy-key
+/// algorithm exists and this connection has not enabled legacy algorithms.
 ///
+/// Both legacy key-exchange algorithms and a server whose only host-key
+/// algorithm is `ssh-dss` are covered; newer-capable servers are not affected.
 /// Host-key changes, authentication failures, network errors, and failures in
 /// other SSH algorithm categories are deliberately left unchanged.
 pub fn add_legacy_algorithm_hint(error: Error, allow_legacy_algorithms: bool) -> Error {
-    if allow_legacy_algorithms || !is_legacy_algorithm_negotiation_failure(&error) {
+    if allow_legacy_algorithms || !is_no_common_algorithm_with_legacy_remedy(&error) {
         return error;
     }
 
@@ -34,23 +36,26 @@ pub fn add_legacy_algorithm_hint(error: Error, allow_legacy_algorithms: bool) ->
     })
 }
 
-fn is_legacy_algorithm_negotiation_failure(error: &Error) -> bool {
+fn is_no_common_algorithm_with_legacy_remedy(error: &Error) -> bool {
     error.chain().any(|cause| {
-        cause
-            .downcast_ref::<russh::Error>()
-            .is_some_and(|error| match error {
-                russh::Error::NoCommonAlgo {
-                    kind: russh::AlgorithmKind::Kex,
-                    ..
-                } => true,
-                russh::Error::NoCommonAlgo {
-                    kind: russh::AlgorithmKind::Key,
-                    theirs,
-                    ..
-                } => theirs.iter().any(|algorithm| algorithm == "ssh-dss"),
-                _ => false,
-            })
+        cause.downcast_ref::<russh::Error>().is_some_and(|error| match error {
+            russh::Error::NoCommonAlgo { kind, theirs, .. } => matches_kind(kind, theirs),
+            _ => false,
+        })
     })
+}
+
+/// The legacy compatibility list only covers SHA-1 KEX, the DSA host-key
+/// algorithm, and hmac-sha1, so a hint is only useful for those failures.
+fn matches_kind(kind: &russh::AlgorithmKind, theirs: &[String]) -> bool {
+    match kind {
+        russh::AlgorithmKind::Kex => true,
+        russh::AlgorithmKind::Key => theirs
+            .iter()
+            .any(|name| matches!(name.as_str(), "ssh-dss" | "ssh-dss-cert-v01@openssh.com")),
+        russh::AlgorithmKind::Mac => theirs.iter().any(|name| name == "hmac-sha1"),
+        _ => false,
+    }
 }
 
 #[cfg(test)]
@@ -58,20 +63,17 @@ mod tests {
     use super::{LegacyAlgorithmRequired, add_legacy_algorithm_hint};
 
     fn no_common_algorithm(kind: russh::AlgorithmKind) -> anyhow::Error {
-        no_common_algorithm_with_theirs(kind, &["theirs"])
+        no_common_algorithm_with_theirs(kind, vec!["theirs".to_owned()])
     }
 
     fn no_common_algorithm_with_theirs(
         kind: russh::AlgorithmKind,
-        theirs: &[&str],
+        theirs: Vec<String>,
     ) -> anyhow::Error {
         russh::Error::NoCommonAlgo {
             kind,
             ours: vec!["ours".to_owned()],
-            theirs: theirs
-                .iter()
-                .map(|algorithm| (*algorithm).to_owned())
-                .collect(),
+            theirs,
         }
         .into()
     }
@@ -97,25 +99,61 @@ mod tests {
     }
 
     #[test]
-    fn host_key_algorithm_negotiation_failure_does_not_add_legacy_kex_hint() {
-        let error =
-            add_legacy_algorithm_hint(no_common_algorithm(russh::AlgorithmKind::Key), false);
-
-        assert!(error.downcast_ref::<LegacyAlgorithmRequired>().is_none());
-        assert!(error.to_string().contains("No common Key algorithm"));
-    }
-
-    #[test]
-    fn disabled_legacy_algorithms_adds_hint_for_ssh_dss_host_key_failure() {
+    fn ssh_dss_host_key_negotiation_failure_suggests_enabling_legacy_algorithms() {
         let error = add_legacy_algorithm_hint(
-            no_common_algorithm_with_theirs(russh::AlgorithmKind::Key, &["ssh-dss"])
-                .context("handshake failed"),
+            no_common_algorithm_with_theirs(
+                russh::AlgorithmKind::Key,
+                vec!["ssh-dss".to_owned()],
+            ),
             false,
         );
 
         assert!(error.downcast_ref::<LegacyAlgorithmRequired>().is_some());
         assert!(error.to_string().contains("No common Key algorithm"));
         assert!(error.to_string().contains("Allow Legacy SSH Algorithms"));
+    }
+
+    #[test]
+    fn unrelated_host_key_algorithm_failure_does_not_suggest_legacy_algorithms() {
+        let error = add_legacy_algorithm_hint(
+            no_common_algorithm_with_theirs(
+                russh::AlgorithmKind::Key,
+                vec!["sk-ssh-ed25519@openssh.com".to_owned()],
+            ),
+            false,
+        );
+
+        assert!(error.downcast_ref::<LegacyAlgorithmRequired>().is_none());
+        assert!(error.to_string().contains("No common Key algorithm"));
+    }
+
+    #[test]
+    fn hmac_sha1_mac_negotiation_failure_suggests_enabling_legacy_algorithms() {
+        let error = add_legacy_algorithm_hint(
+            no_common_algorithm_with_theirs(
+                russh::AlgorithmKind::Mac,
+                vec!["hmac-sha1".to_owned()],
+            ),
+            false,
+        );
+
+        assert!(error.downcast_ref::<LegacyAlgorithmRequired>().is_some());
+        assert!(error.to_string().contains("No common Mac algorithm"));
+        assert!(error.to_string().contains("Allow Legacy SSH Algorithms"));
+    }
+
+    #[test]
+    fn unsupported_mac_negotiation_failure_does_not_suggest_legacy_algorithms() {
+        let error = add_legacy_algorithm_hint(
+            no_common_algorithm_with_theirs(
+                russh::AlgorithmKind::Mac,
+                vec!["hmac-md5".to_owned()],
+            ),
+            false,
+        );
+
+        assert!(error.downcast_ref::<LegacyAlgorithmRequired>().is_none());
+        assert!(error.to_string().contains("No common Mac algorithm"));
     }
 
     #[test]

--- a/crates/ssh/src/ssh.rs
+++ b/crates/ssh/src/ssh.rs
@@ -52,55 +52,38 @@ pub fn build_client_preferred_algorithms_with_legacy(
 ) -> Preferred {
     let mut preferred = Preferred::default();
     if allow_legacy_algorithms {
-        preferred.kex = with_legacy_kex(preferred.kex);
+        let mut kex = preferred.kex.into_owned();
+        let extension_start = kex
+            .iter()
+            .position(|name| {
+                matches!(
+                    *name,
+                    kex::EXTENSION_SUPPORT_AS_CLIENT
+                        | kex::EXTENSION_SUPPORT_AS_SERVER
+                        | kex::EXTENSION_OPENSSH_STRICT_KEX_AS_CLIENT
+                        | kex::EXTENSION_OPENSSH_STRICT_KEX_AS_SERVER
+                )
+            })
+            .unwrap_or(kex.len());
+
+        kex.splice(
+            extension_start..extension_start,
+            [
+                kex::ECDH_SHA2_NISTP256,
+                kex::ECDH_SHA2_NISTP384,
+                kex::ECDH_SHA2_NISTP521,
+                kex::DH_G14_SHA1,
+                // 固定组必须先于 group-exchange：russh 客户端 GEX 允许 MIN 为
+                // 2048 位（更低会被配置拒绝），只支持 1024 位组的旧设备必须
+                // 走固定 DH group1 路径才能完成密钥交换。
+                kex::DH_G1_SHA1,
+                kex::DH_GEX_SHA1,
+            ],
+        );
+        preferred.kex = Cow::Owned(kex);
     }
 
-    preferred.key = build_host_key_algorithms(
-        preferred.key,
-        known_host_key_algorithms,
-        allow_legacy_algorithms,
-    );
-    preferred
-}
-
-fn with_legacy_kex(preferred: Cow<'static, [kex::Name]>) -> Cow<'static, [kex::Name]> {
-    let mut kex = preferred.into_owned();
-    let extension_start = kex
-        .iter()
-        .position(|name| {
-            matches!(
-                *name,
-                kex::EXTENSION_SUPPORT_AS_CLIENT
-                    | kex::EXTENSION_SUPPORT_AS_SERVER
-                    | kex::EXTENSION_OPENSSH_STRICT_KEX_AS_CLIENT
-                    | kex::EXTENSION_OPENSSH_STRICT_KEX_AS_SERVER
-            )
-        })
-        .unwrap_or(kex.len());
-    kex.splice(
-        extension_start..extension_start,
-        [
-            kex::ECDH_SHA2_NISTP256,
-            kex::ECDH_SHA2_NISTP384,
-            kex::ECDH_SHA2_NISTP521,
-            kex::DH_G14_SHA1,
-            kex::DH_GEX_SHA1,
-            kex::DH_G1_SHA1,
-        ],
-    );
-    Cow::Owned(kex)
-}
-
-fn build_host_key_algorithms(
-    preferred: Cow<'static, [Algorithm]>,
-    known_host_key_algorithms: &[String],
-    allow_legacy_algorithms: bool,
-) -> Cow<'static, [Algorithm]> {
-    let mut default_keys = preferred.into_owned();
-    if allow_legacy_algorithms && !default_keys.contains(&Algorithm::Dsa) {
-        default_keys.push(Algorithm::Dsa);
-    }
-
+    let default_keys = preferred.key.into_owned();
     let mut keys = Vec::with_capacity(default_keys.len());
     for known in known_host_key_algorithms {
         for candidate in &default_keys {
@@ -114,7 +97,19 @@ fn build_host_key_algorithms(
             keys.push(candidate);
         }
     }
-    Cow::Owned(keys)
+    if allow_legacy_algorithms {
+        // DSA (`ssh-dss`) host keys and hmac-sha1 predate OpenSSH and only
+        // appear with the explicitly enabled legacy compatibility set. Both
+        // are appended as last-resort fallbacks so modern and known algorithms
+        // stay preferred.
+        keys.push(Algorithm::Dsa);
+
+        let mut mac = preferred.mac.into_owned();
+        mac.push(russh::mac::HMAC_SHA1);
+        preferred.mac = Cow::Owned(mac);
+    }
+    preferred.key = Cow::Owned(keys);
+    preferred
 }
 
 fn host_key_algorithm_matches(candidate: &Algorithm, known: &str) -> bool {
@@ -206,6 +201,13 @@ impl SshConnectConfig {
     }
 }
 
+/// legacy 兼容允许的最低 DH 组位数。russh 客户端配置的下限即为 2048。
+const LEGACY_GEX_MIN_BITS: usize = 2048;
+/// legacy 兼容请求的首选 DH 组位数，避免旧设备按首选位生成过大的组。
+const LEGACY_GEX_PREFERRED_BITS: usize = 2048;
+/// DH 组位数上限，与 russh 默认保持一致。
+const LEGACY_GEX_MAX_BITS: usize = 8192;
+
 fn build_russh_client_config(
     config: &SshConnectConfig,
     identity: &HostKeyIdentity,
@@ -221,6 +223,7 @@ fn build_russh_client_config(
             &known_host_key_algorithms,
             config.allow_legacy_algorithms,
         ),
+        gex: legacy_gex_params(config.allow_legacy_algorithms)?,
         inactivity_timeout: Some(defaults::INACTIVITY_TIMEOUT),
         keepalive_interval: config
             .keepalive_interval
@@ -228,6 +231,23 @@ fn build_russh_client_config(
         keepalive_max: config.keepalive_max.unwrap_or(defaults::KEEPALIVE_MAX),
         ..<_>::default()
     }))
+}
+
+/// 构建 DH 组交换参数。
+///
+/// 旧设备（如仅支持 ssh-dss / hmac-sha1 的服务器）常只提供 2048 位 DH 组，
+/// 而 russh 默认最低接受 3072 位，会导致 `Key exchange init failed`。
+/// 仅当连接显式开启 legacy 兼容时才放宽到 2048，现代路径保持严格默认。
+fn legacy_gex_params(allow_legacy_algorithms: bool) -> Result<client::GexParams> {
+    if allow_legacy_algorithms {
+        Ok(client::GexParams::new(
+            LEGACY_GEX_MIN_BITS,
+            LEGACY_GEX_PREFERRED_BITS,
+            LEGACY_GEX_MAX_BITS,
+        )?)
+    } else {
+        Ok(client::GexParams::default())
+    }
 }
 
 fn host_key_proxy_type(proxy_type: ProxyType) -> HostKeyProxyType {
@@ -2082,9 +2102,14 @@ fn normalize_disconnect_result(
 #[cfg(test)]
 mod port_forward_tests {
     use std::borrow::Cow;
+    use std::future::Future;
     use std::sync::Arc;
     use std::time::Duration;
 
+    use russh::client::GexParams;
+    use russh::kex::DH_GEX_SHA256;
+    use russh::kex::DH_G1_SHA1;
+    use russh::kex::dh::groups::{DH_GROUP1, DH_GROUP14, DhGroup};
     use russh::server::{Auth, Server as _};
     use tempfile::TempDir;
     use tokio::net::TcpListener;
@@ -2095,8 +2120,9 @@ mod port_forward_tests {
         Algorithm, EcdsaCurve, HostKeyDetails, HostKeyIdentity, HostKeyProxyType, HostKeyRoute,
         HostKeyVerifier, JumpServerConnectConfig, Preferred, PrivateKey, ProxyConnectConfig,
         ProxyType, RusshClient, SshAuth, SshClient, SshConnectConfig,
-        build_client_preferred_algorithms, build_client_preferred_algorithms_with_legacy,
-        build_local_forward_bind_addr, build_russh_client_config, normalize_disconnect_result,
+        build_client_preferred_algorithms_with_legacy,
+        build_local_forward_bind_addr, build_russh_client_config, legacy_gex_params,
+        normalize_disconnect_result,
     };
 
     #[derive(Clone)]
@@ -2127,11 +2153,7 @@ mod port_forward_tests {
     }
 
     fn host_key_names(known: &[String]) -> Vec<String> {
-        build_client_preferred_algorithms(known)
-            .key
-            .iter()
-            .map(|algorithm| algorithm.as_str().to_owned())
-            .collect()
+        host_key_names_with_legacy(known, false)
     }
 
     fn host_key_names_with_legacy(known: &[String], allow_legacy_algorithms: bool) -> Vec<String> {
@@ -2139,6 +2161,14 @@ mod port_forward_tests {
             .key
             .iter()
             .map(|algorithm| algorithm.as_str().to_owned())
+            .collect()
+    }
+
+    fn mac_names(allow_legacy_algorithms: bool) -> Vec<String> {
+        build_client_preferred_algorithms_with_legacy(&[], allow_legacy_algorithms)
+            .mac
+            .iter()
+            .map(|name| name.as_ref().to_string())
             .collect()
     }
 
@@ -2312,8 +2342,8 @@ mod port_forward_tests {
 
         assert!(curve25519 < nistp256);
         assert!(nistp256 < group14_sha1);
-        assert!(group14_sha1 < group_exchange_sha1);
-        assert!(group_exchange_sha1 < group1_sha1);
+        assert!(group14_sha1 < group1_sha1);
+        assert!(group1_sha1 < group_exchange_sha1);
     }
 
     #[test]
@@ -2342,21 +2372,97 @@ mod port_forward_tests {
     }
 
     #[test]
-    fn client_enables_ssh_dss_host_keys_only_for_legacy_connections() {
-        let modern = host_key_names_with_legacy(&[], false);
-        let legacy = host_key_names_with_legacy(&[], true);
+    fn legacy_host_key_fallback_offers_ssh_dss_only_when_enabled() {
+        let defaults = host_key_names(&[]);
+        assert!(
+            !defaults.iter().any(|name| name == "ssh-dss"),
+            "ssh-dss must not be offered unless legacy algorithms are enabled"
+        );
 
-        assert!(!modern.iter().any(|algorithm| algorithm == "ssh-dss"));
-        assert!(legacy.iter().any(|algorithm| algorithm == "ssh-dss"));
-        assert_eq!(legacy.len(), modern.len() + 1);
-        assert_eq!(&legacy[..modern.len()], modern);
+        let legacy = host_key_names_with_legacy(&[], true);
+        assert_eq!(
+            legacy
+                .iter()
+                .filter(|name| name.as_str() == "ssh-dss")
+                .count(),
+            1,
+            "ssh-dss should be offered exactly once with legacy algorithms"
+        );
+        assert_eq!(
+            legacy.last().map(String::as_str),
+            Some("ssh-dss"),
+            "ssh-dss should be a last-resort fallback"
+        );
+        assert_eq!(
+            legacy.first().map(String::as_str),
+            Some("ssh-ed25519"),
+            "modern host-key algorithms must stay preferred"
+        );
+        for default in defaults {
+            assert!(
+                legacy.contains(&default),
+                "default host-key algorithm {default} must remain enabled"
+            );
+        }
     }
 
     #[test]
-    fn client_promotes_known_ssh_dss_key_after_legacy_opt_in() {
-        let promoted = host_key_names_with_legacy(&["ssh-dss".to_owned()], true);
+    fn legacy_host_key_fallback_keeps_known_algorithms_ahead_of_ssh_dss() {
+        let promoted = host_key_names_with_legacy(&["ecdsa-sha2-nistp256".to_owned()], true);
 
-        assert_eq!(promoted.first().map(String::as_str), Some("ssh-dss"));
+        assert_eq!(
+            promoted.first().map(String::as_str),
+            Some("ecdsa-sha2-nistp256")
+        );
+        assert_eq!(
+            promoted.last().map(String::as_str),
+            Some("ssh-dss"),
+            "ssh-dss must never displace a known or modern host-key algorithm"
+        );
+    }
+
+    #[test]
+    fn legacy_mac_fallback_offers_hmac_sha1_only_when_enabled() {
+        let defaults = mac_names(false);
+        assert_eq!(defaults, default_mac_names());
+        assert!(
+            !defaults.iter().any(|name| name == "hmac-sha1"),
+            "hmac-sha1 must not be offered unless legacy algorithms are enabled"
+        );
+
+        let legacy = mac_names(true);
+        assert_eq!(
+            legacy
+                .iter()
+                .filter(|name| name.as_str() == "hmac-sha1")
+                .count(),
+            1,
+            "hmac-sha1 should be offered exactly once with legacy algorithms"
+        );
+        assert_eq!(
+            legacy.last().map(String::as_str),
+            Some("hmac-sha1"),
+            "hmac-sha1 should be a last-resort fallback"
+        );
+        assert_eq!(
+            legacy.first().map(String::as_str),
+            Some("hmac-sha2-512-etm@openssh.com"),
+            "modern MAC algorithms must stay preferred"
+        );
+        for default in defaults {
+            assert!(
+                legacy.contains(&default),
+                "default MAC algorithm {default} must remain enabled"
+            );
+        }
+    }
+
+    fn default_mac_names() -> Vec<String> {
+        Preferred::default()
+            .mac
+            .iter()
+            .map(|name| name.as_ref().to_string())
+            .collect()
     }
 
     #[test]
@@ -2683,6 +2789,327 @@ zsXyAAAAAAE=
             panic!("a different fallback key must remain rejected");
         };
         assert!(error.to_string().contains("changed SSH host key"));
+    }
+
+    #[tokio::test]
+    async fn client_connects_when_the_server_only_offers_ssh_dss_host_key() {
+        let (address, server_task) = spawn_ssh_dss_host_key_test_server().await;
+        let mut config = host_key_test_config(address, HostKeyVerifier::insecure());
+        config.allow_legacy_algorithms = true;
+
+        let result = RusshClient::connect(config).await;
+        server_task.abort();
+
+        result.expect("server offering only ssh-dss should connect with legacy algorithms enabled");
+    }
+
+    #[tokio::test]
+    async fn client_rejects_ssh_dss_only_server_when_legacy_algorithms_are_disabled() {
+        let (address, server_task) = spawn_ssh_dss_host_key_test_server().await;
+        let config = host_key_test_config(address, HostKeyVerifier::insecure());
+
+        let result = RusshClient::connect(config).await;
+        server_task.abort();
+
+        let Err(error) = result else {
+            panic!("ssh DSA host key must not be negotiated unless the connection opts in");
+        };
+        assert!(error.downcast_ref::<LegacyAlgorithmRequired>().is_some());
+        assert!(error.to_string().contains("No common Key algorithm"));
+        assert!(error.to_string().contains("Allow Legacy SSH Algorithms"));
+    }
+
+    async fn spawn_ssh_dss_host_key_test_server() -> (
+        std::net::SocketAddr,
+        tokio::task::JoinHandle<std::io::Result<()>>,
+    ) {
+        let socket = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("DSS host-key test server should bind");
+        let address = socket
+            .local_addr()
+            .expect("DSS host-key test server should have an address");
+        let dsa = PrivateKey::random(&mut rand_010::rng(), Algorithm::Dsa)
+            .expect("DSA host key should be generated");
+        let server_config = Arc::new(russh::server::Config {
+            auth_rejection_time: Duration::ZERO,
+            auth_rejection_time_initial: Some(Duration::ZERO),
+            keys: vec![dsa],
+            preferred: Preferred {
+                key: Cow::Owned(vec![Algorithm::Dsa]),
+                ..Preferred::default()
+            },
+            ..Default::default()
+        });
+        let server_task = tokio::spawn(async move {
+            let mut server = CompatibilityTestServer;
+            server.run_on_socket(server_config, &socket).await
+        });
+        (address, server_task)
+    }
+
+    #[tokio::test]
+    async fn client_connects_when_the_server_only_offers_hmac_sha1_mac() {
+        let (address, server_task) = spawn_legacy_mac_test_server().await;
+        let mut config = host_key_test_config(address, HostKeyVerifier::insecure());
+        config.allow_legacy_algorithms = true;
+
+        let result = RusshClient::connect(config).await;
+        server_task.abort();
+
+        result.expect("server offering only hmac-sha1 should connect with legacy algorithms enabled");
+    }
+
+    #[tokio::test]
+    async fn client_rejects_hmac_sha1_only_server_when_legacy_algorithms_are_disabled() {
+        let (address, server_task) = spawn_legacy_mac_test_server().await;
+        let config = host_key_test_config(address, HostKeyVerifier::insecure());
+
+        let result = RusshClient::connect(config).await;
+        server_task.abort();
+
+        let Err(error) = result else {
+            panic!("hmac-sha1 must not be negotiated unless the connection opts in");
+        };
+        assert!(error.downcast_ref::<LegacyAlgorithmRequired>().is_some());
+        assert!(error.to_string().contains("No common Mac algorithm"));
+        assert!(error.to_string().contains("Allow Legacy SSH Algorithms"));
+    }
+
+    async fn spawn_legacy_mac_test_server() -> (
+        std::net::SocketAddr,
+        tokio::task::JoinHandle<std::io::Result<()>>,
+    ) {
+        let socket = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("legacy MAC test server should bind");
+        let address = socket
+            .local_addr()
+            .expect("legacy MAC test server should have an address");
+        let ed25519 = PrivateKey::random(&mut rand_010::rng(), Algorithm::Ed25519)
+            .expect("Ed25519 host key should be generated");
+        let server_config = Arc::new(russh::server::Config {
+            auth_rejection_time: Duration::ZERO,
+            auth_rejection_time_initial: Some(Duration::ZERO),
+            keys: vec![ed25519],
+            preferred: Preferred {
+                mac: Cow::Owned(vec![russh::mac::HMAC_SHA1]),
+                // AEAD ciphers have integrated authentication and skip MAC
+                // negotiation entirely, so pin a MAC-bearing cipher to reproduce
+                // the legacy-device path.
+                cipher: Cow::Owned(vec![russh::cipher::AES_128_CTR]),
+                ..Preferred::default()
+            },
+            ..Default::default()
+        });
+        let server_task = tokio::spawn(async move {
+            let mut server = CompatibilityTestServer;
+            server.run_on_socket(server_config, &socket).await
+        });
+        (address, server_task)
+    }
+
+    #[test]
+    fn legacy_dh_group_accepts_2048_bit_groups_only_when_enabled() {
+        let strict = legacy_gex_params(false).expect("default gex params should build");
+        let legacy = legacy_gex_params(true).expect("legacy gex params should build");
+
+        assert_eq!(legacy.min_group_size(), 2048);
+        assert_eq!(legacy.preferred_group_size(), 2048);
+        assert_eq!(legacy.max_group_size(), 8192);
+        assert!(
+            strict.min_group_size() > legacy.min_group_size(),
+            "modern connections must keep a stricter DH group floor"
+        );
+        assert_ne!(strict.preferred_group_size(), legacy.preferred_group_size());
+        assert_eq!(strict.max_group_size(), legacy.max_group_size());
+    }
+
+    #[test]
+    fn legacy_kex_prefers_fixed_group1_before_group_exchange() {
+        let names = kex_names(true);
+        let group1 = names
+            .iter()
+            .position(|name| name == "diffie-hellman-group1-sha1")
+            .expect("legacy list must still offer fixed group1 SHA-1");
+        let group_exchange = names
+            .iter()
+            .position(|name| name == "diffie-hellman-group-exchange-sha1")
+            .expect("legacy list must still offer group-exchange SHA-1");
+
+        assert!(
+            group1 < group_exchange,
+            "fixed group1 must be preferred over group-exchange so 1024-bit \
+             devices never hit the 2048-bit GEX floor"
+        );
+        assert!(!kex_names(false).contains(&"diffie-hellman-group1-sha1".to_owned()));
+    }
+
+    #[derive(Clone)]
+    struct LegacyGexTestServer;
+
+    impl russh::server::Server for LegacyGexTestServer {
+        type Handler = Self;
+
+        fn new_client(&mut self, _: Option<std::net::SocketAddr>) -> Self::Handler {
+            self.clone()
+        }
+    }
+
+    impl russh::server::Handler for LegacyGexTestServer {
+        type Error = anyhow::Error;
+
+        async fn auth_password(&mut self, _: &str, _: &str) -> Result<Auth, Self::Error> {
+            Ok(Auth::Accept)
+        }
+
+        // 模拟只能生成 2048 位 DH 组的旧设备：无视客户端请求范围，固定返回 group14。
+        fn lookup_dh_gex_group(
+            &mut self,
+            _gex_params: &GexParams,
+        ) -> impl Future<Output = Result<Option<DhGroup>, Self::Error>> + Send {
+            async { Ok(Some(DH_GROUP14.clone())) }
+        }
+    }
+
+    #[tokio::test]
+    async fn client_connects_when_server_only_supports_2048_bit_dh_group() {
+        let (address, server_task) = spawn_legacy_gex_test_server().await;
+        let mut config = host_key_test_config(address, HostKeyVerifier::insecure());
+        config.allow_legacy_algorithms = true;
+
+        let result = RusshClient::connect(config).await;
+        server_task.abort();
+
+        result.expect("a 2048-bit DH group should connect with legacy algorithms enabled");
+    }
+
+    #[tokio::test]
+    async fn client_rejects_2048_bit_dh_group_when_legacy_algorithms_are_disabled() {
+        let (address, server_task) = spawn_legacy_gex_test_server().await;
+        let config = host_key_test_config(address, HostKeyVerifier::insecure());
+
+        let result = RusshClient::connect(config).await;
+        server_task.abort();
+
+        let Err(error) = result else {
+            panic!("a 2048-bit DH group must not be accepted unless the connection opts in");
+        };
+        assert!(error.to_string().contains("exchange init failed"));
+    }
+
+    async fn spawn_legacy_gex_test_server() -> (
+        std::net::SocketAddr,
+        tokio::task::JoinHandle<std::io::Result<()>>,
+    ) {
+        let socket = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("legacy gex test server should bind");
+        let address = socket
+            .local_addr()
+            .expect("legacy gex test server should have an address");
+        let ed25519 = PrivateKey::random(&mut rand_010::rng(), Algorithm::Ed25519)
+            .expect("Ed25519 host key should be generated");
+        let server_config = Arc::new(russh::server::Config {
+            auth_rejection_time: Duration::ZERO,
+            auth_rejection_time_initial: Some(Duration::ZERO),
+            keys: vec![ed25519],
+            preferred: Preferred {
+                kex: Cow::Owned(vec![DH_GEX_SHA256]),
+                ..Preferred::default()
+            },
+            ..Default::default()
+        });
+        let server_task = tokio::spawn(async move {
+            let mut server = LegacyGexTestServer;
+            server.run_on_socket(server_config, &socket).await
+        });
+        (address, server_task)
+    }
+
+    #[tokio::test]
+    async fn client_connects_when_server_offers_only_fixed_group1_and_gex() {
+        let (address, server_task) = spawn_legacy_group1_test_server().await;
+        let mut config = host_key_test_config(address, HostKeyVerifier::insecure());
+        config.allow_legacy_algorithms = true;
+
+        let result = RusshClient::connect(config).await;
+        server_task.abort();
+
+        result.expect(
+            "a 1024-bit device offering fixed group1 must connect with legacy algorithms enabled",
+        );
+    }
+
+    #[tokio::test]
+    async fn client_rejects_1024_bit_fixed_group_when_legacy_algorithms_are_disabled() {
+        let (address, server_task) = spawn_legacy_group1_test_server().await;
+        let config = host_key_test_config(address, HostKeyVerifier::insecure());
+
+        let result = RusshClient::connect(config).await;
+        server_task.abort();
+
+        let Err(error) = result else {
+            panic!("a 1024-bit fixed group must not be accepted unless the connection opts in");
+        };
+        assert!(error.to_string().contains("No common Kex algorithm"));
+        assert!(error.to_string().contains("Allow Legacy SSH Algorithms"));
+    }
+
+    async fn spawn_legacy_group1_test_server() -> (
+        std::net::SocketAddr,
+        tokio::task::JoinHandle<std::io::Result<()>>,
+    ) {
+        let socket = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("legacy group1 test server should bind");
+        let address = socket
+            .local_addr()
+            .expect("legacy group1 test server should have an address");
+        let ed25519 = PrivateKey::random(&mut rand_010::rng(), Algorithm::Ed25519)
+            .expect("Ed25519 host key should be generated");
+        let server_config = Arc::new(russh::server::Config {
+            auth_rejection_time: Duration::ZERO,
+            auth_rejection_time_initial: Some(Duration::ZERO),
+            keys: vec![ed25519],
+            preferred: Preferred {
+                kex: Cow::Owned(vec![russh::kex::DH_GEX_SHA1, DH_G1_SHA1]),
+                ..Preferred::default()
+            },
+            ..Default::default()
+        });
+        let server_task = tokio::spawn(async move {
+            let mut server = FixedGroup1TestServer;
+            server.run_on_socket(server_config, &socket).await
+        });
+        (address, server_task)
+    }
+
+    #[derive(Clone)]
+    struct FixedGroup1TestServer;
+
+    impl russh::server::Server for FixedGroup1TestServer {
+        type Handler = Self;
+
+        fn new_client(&mut self, _: Option<std::net::SocketAddr>) -> Self::Handler {
+            self.clone()
+        }
+    }
+
+    impl russh::server::Handler for FixedGroup1TestServer {
+        type Error = anyhow::Error;
+
+        async fn auth_password(&mut self, _: &str, _: &str) -> Result<Auth, Self::Error> {
+            Ok(Auth::Accept)
+        }
+
+        // 模拟只能生成 1024 位 DH 组的更旧设备：无视客户端请求范围，固定返回 group1。
+        fn lookup_dh_gex_group(
+            &mut self,
+            _gex_params: &GexParams,
+        ) -> impl Future<Output = Result<Option<DhGroup>, Self::Error>> + Send {
+            async { Ok(Some(DH_GROUP1.clone())) }
+        }
     }
 
     #[tokio::test]

--- a/crates/ssh/tests/legacy_dh.rs
+++ b/crates/ssh/tests/legacy_dh.rs
@@ -1,0 +1,88 @@
+//! 老旧 SSH 设备（仅提供 1024 位 DH / ssh-dss / CBC / hmac-sha1）连接的验证契约。
+//!
+//! 这些设备由用户显式提供用于本地回归验证，因此默认 `#[ignore]`，不会在常规 CI
+//! 中生效；需要手动验证时用：
+//! `cargo test -p ssh --test legacy_dh -- --ignored`
+//!
+//! 依赖两台 OpenSSH 老服务器的既有行为（见 AGENTS 中“老旧设备 DH 组”经验）：
+//! - 172.29.254.120：OpenSSH_5.2，KEX 含 group1-sha1 / group14-sha1 / GEX-sha1，host key 仅 ssh-dss，
+//!   CBC 系 cipher，MAC 含 hmac-sha1。
+//! - 172.29.254.122：OpenSSH_3.8.1p1，KEX 仅 group-exchange-sha1 / group1-sha1，host key 仅 ssh-dss，
+//!   MAC 含 hmac-md5 / hmac-sha1 / hmac-ripemd160。
+
+use std::time::Duration;
+
+use ssh::{
+    ChannelEvent, HostKeyVerifier, RusshClient, SshAuth, SshChannel, SshClient, SshConnectConfig,
+};
+
+const LEGACY_DEVICES: &[(&str, &str)] = &[
+    ("172.29.254.120", "OpenSSH_5.2"),
+    ("172.29.254.122", "OpenSSH_3.8.1p1"),
+];
+const USERNAME: &str = "admin";
+const PASSWORD: &str = "password";
+
+fn config_for(host: &str, allow_legacy_algorithms: bool) -> SshConnectConfig {
+    SshConnectConfig {
+        host: host.to_string(),
+        port: 22,
+        username: USERNAME.to_string(),
+        auth: SshAuth::Password(PASSWORD.to_string()),
+        timeout: Some(Duration::from_secs(20)),
+        keepalive_interval: None,
+        keepalive_max: None,
+        jump_server: None,
+        proxy: None,
+        keyboard_interactive_responder: None,
+        host_key_verifier: HostKeyVerifier::insecure(),
+        x11_forwarding: false,
+        allow_legacy_algorithms,
+    }
+}
+
+async fn run_echo_check(host: &str) -> anyhow::Result<String> {
+    let mut client = RusshClient::connect(config_for(host, true)).await?;
+    assert!(client.is_connected(), "legacy client should be connected after handshake");
+
+    let mut channel = client.open_channel().await?;
+    channel.exec("echo legacy-dh-${HOSTNAME:-ok}").await?;
+
+    let mut stdout = Vec::new();
+    while let Some(event) = channel.recv().await {
+        match event {
+            ChannelEvent::Data(data) => stdout.extend_from_slice(&data),
+            ChannelEvent::Close => break,
+            _ => {}
+        }
+    }
+    let _ = client.disconnect().await;
+    Ok(String::from_utf8_lossy(&stdout).to_string())
+}
+
+#[tokio::test]
+#[ignore = "需要用户提供的两台老旧 SSH 设备才能进行真实连接验证"]
+async fn legacy_devices_connect_with_1024bit_dh() {
+    for (host, banner_hint) in LEGACY_DEVICES {
+        let output = run_echo_check(host)
+            .await
+            .unwrap_or_else(|e| panic!("连接/认证/执行失败 on {host} ({banner_hint}): {e:?}"));
+        assert!(
+            output.contains("legacy-dh"),
+            "预期在 {host} ({banner_hint}) 上通过 1024 位 DH 协商并回显成功，实际输出: {output:?}"
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore = "需要用户提供的两台老旧 SSH 设备才能进行真实连接验证"]
+async fn stock_algorithms_reject_legacy_devices() {
+    // 反向契约：不启用 legacy 算法时，这些设备必须协商失败（只能证明该改动确实起决定作用）。
+    for (host, banner_hint) in LEGACY_DEVICES {
+        let result = RusshClient::connect(config_for(host, false)).await;
+        assert!(
+            result.is_err(),
+            "{host} ({banner_hint}) 在不启用 legacy 算法时不应连接成功"
+        );
+    }
+}


### PR DESCRIPTION
- 支持老旧 SSH 设备的 1024 位 DH 组协商
- 调整 GEX 参数与 KEX 顺序，避免 Key exchange init failed
- 补充真实连接测试与错误提示

Closes #[issue number]

## Description

Describe in English for the changes made in this pull request and the problem it solves.
Please keep **1 PR to solve 1 problem**, and keep **Small improvements should be small modifications** to make PR easier to review and to merge.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| [Put Before Screenshot here] | [Put After Screenshot here] |

## Break Changes

Describe any breaking changes introduced by this pull request. If none, remove this section.

- Change 1

```diff
- Old code snippet
+ New code snippet
```

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
