### PR TITLE
feat(tabs): number duplicated tabs and adaptive width

### DIFF
--- a/crates/core/src/tab_actions.rs
+++ b/crates/core/src/tab_actions.rs
@@ -45,6 +45,74 @@ pub fn duplicate_tab_id(source_id: &str, mut exists: impl FnMut(&str) -> bool) -
     }
 }
 
+/// 复制标签页时使用的新标题：去掉源标题已有的 "(n)" 后缀后，追加最小的可用序号。
+/// 例如 "172.29.13.200" -> "172.29.13.200(1)"，"172.29.13.200(1)" -> "172.29.13.200(2)"。
+pub fn next_duplicate_tab_title(
+    source_title: &str,
+    mut exists: impl FnMut(&str) -> bool,
+) -> String {
+    let base_title = strip_duplicate_suffix(source_title);
+    let mut index = 1;
+    loop {
+        let candidate = format!("{base_title}({index})");
+        if !exists(&candidate) {
+            return candidate;
+        }
+        index += 1;
+    }
+}
+
+/// 去掉标题末尾的 "(正整数)" 后缀，如 "172.29.13.200(1)" -> "172.29.13.200"。
+fn strip_duplicate_suffix(title: &str) -> &str {
+    let Some(open) = title.rfind('(') else {
+        return title;
+    };
+    let close = title.len().saturating_sub(1);
+    if title.as_bytes().get(close) != Some(&b')') {
+        return title;
+    }
+    let number = &title[open + 1..close];
+    if !number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit()) {
+        let base = &title[..open];
+        if base.is_empty() { title } else { base }
+    } else {
+        title
+    }
+}
+
+/// 解析 "base(n)" 形式标题中的序号 n（n >= 1）。
+pub fn parse_duplicate_index(title: &str, base_title: &str) -> Option<usize> {
+    let suffix = title.strip_prefix(base_title)?;
+    let number = suffix.strip_prefix('(')?.strip_suffix(')')?;
+    let index: usize = number.parse().ok()?;
+    (index >= 1).then_some(index)
+}
+
+/// 计算同基础名称的下一个可用标签序号（从 1 开始）。
+/// 不存在同名标签时返回 None（首个标签不加序号）。
+pub fn next_duplicate_tab_index<'a>(
+    base_title: &str,
+    titles: impl IntoIterator<Item = &'a str>,
+) -> Option<usize> {
+    let mut used: HashSet<usize> = HashSet::new();
+    let mut found_base = false;
+    for title in titles {
+        if title == base_title {
+            found_base = true;
+        } else if let Some(index) = parse_duplicate_index(title, base_title) {
+            used.insert(index);
+        }
+    }
+    if !found_base && used.is_empty() {
+        return None;
+    }
+    let mut index = 1;
+    while used.contains(&index) {
+        index += 1;
+    }
+    Some(index)
+}
+
 pub fn mark_tab_activity(
     activity_tabs: &mut HashSet<String>,
     tab_id: &str,
@@ -103,6 +171,102 @@ mod tests {
         let id = duplicate_tab_id("terminal-1", |candidate| existing.contains(&candidate));
 
         assert_eq!("terminal-1-duplicate-3", id);
+    }
+
+    #[test]
+    fn duplicate_tab_title_numbers_the_first_duplicate() {
+        let existing = ["172.29.13.200"];
+
+        let title =
+            next_duplicate_tab_title("172.29.13.200", |candidate| existing.contains(&candidate));
+
+        assert_eq!("172.29.13.200(1)", title);
+    }
+
+    #[test]
+    fn duplicate_tab_title_increments_sequentially() {
+        let existing = ["172.29.13.200", "172.29.13.200(1)"];
+
+        let title =
+            next_duplicate_tab_title("172.29.13.200", |candidate| existing.contains(&candidate));
+
+        assert_eq!("172.29.13.200(2)", title);
+    }
+
+    #[test]
+    fn duplicate_tab_title_uses_next_available_gap() {
+        let existing = ["172.29.13.200", "172.29.13.200(1)", "172.29.13.200(3)"];
+
+        let title =
+            next_duplicate_tab_title("172.29.13.200", |candidate| existing.contains(&candidate));
+
+        assert_eq!("172.29.13.200(2)", title);
+    }
+
+    #[test]
+    fn duplicating_numbered_tab_keeps_the_original_base() {
+        let existing = ["172.29.13.200", "172.29.13.200(1)", "172.29.13.200(2)"];
+
+        let title = next_duplicate_tab_title("172.29.13.200(2)", |candidate| {
+            existing.contains(&candidate)
+        });
+
+        assert_eq!("172.29.13.200(3)", title);
+    }
+
+    #[test]
+    fn strip_duplicate_suffix_ignores_non_numeric_tail() {
+        assert_eq!("172.29.13.200", strip_duplicate_suffix("172.29.13.200(1)"));
+        assert_eq!("host(prod)", strip_duplicate_suffix("host(prod)"));
+        assert_eq!("host(1)x", strip_duplicate_suffix("host(1)x"));
+        assert_eq!("host", strip_duplicate_suffix("host"));
+    }
+
+    #[test]
+    fn parse_duplicate_index_matches_exact_base_with_suffix() {
+        assert_eq!(
+            Some(1),
+            parse_duplicate_index("172.29.13.200(1)", "172.29.13.200")
+        );
+        assert_eq!(Some(12), parse_duplicate_index("db(12)", "db"));
+        assert_eq!(
+            None,
+            parse_duplicate_index("172.29.13.200", "172.29.13.200")
+        );
+        assert_eq!(None, parse_duplicate_index("db(0)", "db"));
+        assert_eq!(None, parse_duplicate_index("db(x)", "db"));
+        assert_eq!(None, parse_duplicate_index("other(1)", "db"));
+    }
+
+    #[test]
+    fn next_duplicate_tab_index_starts_at_one_and_reuses_freed_numbers() {
+        assert_eq!(
+            None,
+            next_duplicate_tab_index("db", ["other"].iter().copied())
+        );
+
+        assert_eq!(
+            Some(1),
+            next_duplicate_tab_index("db", ["db"].iter().copied())
+        );
+
+        assert_eq!(
+            Some(1),
+            next_duplicate_tab_index("db", ["db", "db(3)"].iter().copied())
+        );
+
+        assert_eq!(
+            Some(2),
+            next_duplicate_tab_index("db", ["db", "db(1)"].iter().copied())
+        );
+    }
+
+    #[test]
+    fn next_duplicate_tab_index_continues_when_original_is_gone() {
+        assert_eq!(
+            Some(2),
+            next_duplicate_tab_index("db", ["db(1)"].iter().copied())
+        );
     }
 
     #[test]

--- a/crates/core/src/tab_container.rs
+++ b/crates/core/src/tab_container.rs
@@ -5,7 +5,7 @@ use crate::sidebar_contribution::{
 };
 use crate::tab_actions::{
     TAB_TITLE_METADATA_KEY, clear_tab_activity, duplicate_tab_id, mark_tab_activity,
-    normalize_title, resolve_tab_title,
+    next_duplicate_tab_title, normalize_title, resolve_tab_title,
 };
 use crate::tab_navigation::{ActiveTabSlot, tab_number_target};
 use crate::tab_switcher::{TabSwitcherEntry, open_tab_switcher_dialog};
@@ -38,6 +38,15 @@ use std::sync::Arc;
 const TAB_MIN_WIDTH: Pixels = px(60.0);
 const TAB_RENAME_MIN_WIDTH: Pixels = px(280.0);
 const TAB_CONTAINER_CONTEXT: &str = "TabContainer";
+
+/// 标签最大宽度硬上限，防止超长标题撑爆标签栏。
+const TAB_HARD_MAX_WIDTH: f32 = 400.0;
+/// 每字符宽度的宽裕估算（含 CJK 余量），用于计算 max_w 上限。
+/// 实际渲染宽度由 GPUI flex 布局按真实字体测量，此值仅做上限保护。
+const TAB_CHAR_WIDTH_BUDGET: f32 = 12.0;
+/// 标签中除标题外的固定 UI 预算：序号 + 图标 + 状态标 + 关闭按钮 +
+/// gap_2 间距 + px_3 内边距。宽裕估算，确保上限不误伤正常标题。
+const TAB_CHROME_BUDGET: f32 = 160.0;
 
 #[derive(Clone, Copy)]
 struct TitlebarPlatform {
@@ -437,6 +446,10 @@ pub trait TabContent: EventEmitter<TabContentEvent> + Render + Focusable {
         true
     }
 
+    /// Called when the tab bar applies a final displayed title (rename or
+    /// duplicate suffix), so the content can keep derived labels in sync.
+    fn apply_title(&mut self, title: &str, window: &mut Window, cx: &mut Context<Self>) {}
+
     /// Whether this tab can be duplicated from the tab bar menu.
     fn can_duplicate(&self, cx: &App) -> bool {
         false
@@ -537,6 +550,7 @@ pub trait TabContentView: 'static + Send + Sync {
     fn closeable(&self, cx: &App) -> bool;
     fn can_rename(&self, cx: &App) -> bool;
     fn rename(&self, title: &str, window: &mut Window, cx: &mut App) -> bool;
+    fn apply_title(&self, title: &str, window: &mut Window, cx: &mut App);
     fn can_duplicate(&self, cx: &App) -> bool;
     fn duplicate(&self, window: &mut Window, cx: &mut App) -> Option<Arc<dyn TabContentView>>;
     fn on_activate(&self, window: &mut Window, cx: &mut App);
@@ -609,6 +623,10 @@ impl<T: TabContent> TabContentView for Entity<T> {
 
     fn rename(&self, title: &str, window: &mut Window, cx: &mut App) -> bool {
         self.update(cx, |this, cx| this.rename(title, window, cx))
+    }
+
+    fn apply_title(&self, title: &str, window: &mut Window, cx: &mut App) {
+        self.update(cx, |this, cx| this.apply_title(title, window, cx));
     }
 
     fn can_duplicate(&self, cx: &App) -> bool {
@@ -2351,6 +2369,7 @@ impl TabContainer {
         if self.tabs[index].set_title_override(&title) {
             cx.emit(TabContainerEvent::LayoutChanged);
         }
+        self.tabs[index].content().apply_title(&title, window, cx);
         cx.notify();
     }
 
@@ -2372,14 +2391,25 @@ impl TabContainer {
         let duplicate_id = duplicate_tab_id(source_id.as_ref(), |candidate| {
             self.tabs.iter().any(|tab| tab.id() == candidate)
         });
+        // 复制标签时自动对标签名追加序号，如 "172.29.13.200" -> "172.29.13.200(1)"
+        let source_title = self.tabs[index].title(cx);
+        let duplicate_title = next_duplicate_tab_title(source_title.as_ref(), |candidate| {
+            self.tabs
+                .iter()
+                .any(|tab| tab.title(cx).as_ref() == candidate)
+        });
         let from = self.tabs[index].from();
         let metadata = self.tabs[index].metadata().clone();
-        let duplicate = TabItem {
+        let mut duplicate = TabItem {
             id: SharedString::from(duplicate_id.clone()),
             from,
             metadata,
             content: duplicate_content,
         };
+        duplicate.set_title_override(&duplicate_title);
+        duplicate
+            .content()
+            .apply_title(duplicate_title.as_ref(), window, cx);
         self.subscribe_tab_content(&duplicate, window, cx);
 
         let insert_index = (index + 1).min(self.tabs.len());
@@ -2567,9 +2597,18 @@ impl TabContainer {
         self.add_and_activate_tab_with_focus(tab, window, cx);
     }
 
+    /// 计算标签的 max_w 上限。实际渲染宽度由 GPUI flex 布局按真实字体测量，
+    /// 此处只提供宽裕的上限保护，避免超长标题撑爆标签栏。优先使用内容自带
+    /// 的 `width_size`；否则按标题字符数估算一个绝不误伤正常标题的上限。
     fn get_tab_max_width(&self, tab: &TabItem, cx: &App) -> gpui::Pixels {
-        let size = tab.content().width_size(cx).unwrap_or(self.size);
-        self.size_to_pixels(size)
+        if let Some(size) = tab.content().width_size(cx) {
+            return self.size_to_pixels(size);
+        }
+
+        let title = tab.title(cx);
+        let char_count = title.chars().count() as f32;
+        let estimated = char_count * TAB_CHAR_WIDTH_BUDGET + TAB_CHROME_BUDGET;
+        px(estimated.min(TAB_HARD_MAX_WIDTH))
     }
 
     fn size_to_pixels(&self, size: Size) -> gpui::Pixels {
@@ -3866,7 +3905,6 @@ impl TabContainer {
                             .items_center()
                             .gap_2()
                             .h(tab_item_height)
-                            .text_ellipsis()
                             .min_w(tab_min_width)
                             .max_w(tab_max_width)
                             .px_3()

--- a/crates/core/src/tab_content_contract_tests.rs
+++ b/crates/core/src/tab_content_contract_tests.rs
@@ -11,6 +11,8 @@ fn tab_content_view_exposes_tab_action_contracts() {
     let _can_rename: fn(&dyn TabContentView, &App) -> bool = <dyn TabContentView>::can_rename;
     let _rename: fn(&dyn TabContentView, &str, &mut gpui::Window, &mut App) -> bool =
         <dyn TabContentView>::rename;
+    let _apply_title: fn(&dyn TabContentView, &str, &mut gpui::Window, &mut App) =
+        <dyn TabContentView>::apply_title;
     let _can_duplicate: fn(&dyn TabContentView, &App) -> bool = <dyn TabContentView>::can_duplicate;
     let _duplicate: fn(
         &dyn TabContentView,

--- a/crates/terminal_view/src/broadcast_input.rs
+++ b/crates/terminal_view/src/broadcast_input.rs
@@ -42,6 +42,17 @@ impl BroadcastInputHub {
         self.clients.remove(&id).is_some()
     }
 
+    pub fn update_label(&mut self, id: BroadcastClientId, label: String) -> bool {
+        match self.clients.get_mut(&id) {
+            Some(existing) => {
+                let changed = *existing != label;
+                *existing = label;
+                changed
+            }
+            None => false,
+        }
+    }
+
     pub fn set_enabled(&mut self, enabled: bool) -> bool {
         let changed = self.enabled != enabled;
         self.enabled = enabled;
@@ -228,5 +239,17 @@ mod tests {
 
         hub.toggle_selected(target);
         assert_eq!(0, hub.selected_count());
+    }
+
+    #[test]
+    fn update_label_refreshes_the_visible_target_label() {
+        let mut hub = BroadcastInputHub::default();
+        let target = hub.register("172.29.13.200");
+
+        assert!(hub.update_label(target, "172.29.13.200(1)".to_string()));
+        assert_eq!("172.29.13.200(1)", hub.snapshot().targets[0].label.as_str());
+
+        assert!(!hub.update_label(target, "172.29.13.200(1)".to_string()));
+        assert!(!hub.update_label(9999, "unknown".to_string()));
     }
 }

--- a/crates/terminal_view/src/broadcast_registry.rs
+++ b/crates/terminal_view/src/broadcast_registry.rs
@@ -36,6 +36,17 @@ impl BroadcastInputRegistry {
         }
     }
 
+    pub(crate) fn update_label(
+        &mut self,
+        id: BroadcastClientId,
+        label: String,
+        cx: &mut Context<Self>,
+    ) {
+        if self.hub.update_label(id, label) {
+            cx.notify();
+        }
+    }
+
     pub(crate) fn set_enabled(&mut self, enabled: bool, cx: &mut Context<Self>) {
         if self.hub.set_enabled(enabled) {
             cx.notify();

--- a/crates/terminal_view/src/view/registrations.rs
+++ b/crates/terminal_view/src/view/registrations.rs
@@ -39,6 +39,19 @@ impl TerminalView {
         }
     }
 
+    /// 让广播输入面板中的标签与标签页最终显示的标题保持一致。
+    pub(crate) fn sync_broadcast_label(&mut self, title: &str, cx: &mut Context<Self>) {
+        let Some(client_id) = self.broadcast_client_id else {
+            return;
+        };
+        let Some(registry) = broadcast_input_registry(cx) else {
+            return;
+        };
+        registry.update(cx, |registry, cx| {
+            registry.update_label(client_id, title.to_string(), cx);
+        });
+    }
+
     pub(super) fn broadcast_user_input(&self, data: &[u8], cx: &mut Context<Self>) {
         if !self.is_live_ssh_terminal(cx) {
             return;

--- a/crates/terminal_view/src/view/tab_content.rs
+++ b/crates/terminal_view/src/view/tab_content.rs
@@ -121,6 +121,10 @@ impl TabContent for TerminalView {
         Task::ready(true)
     }
 
+    fn apply_title(&mut self, title: &str, _window: &mut Window, cx: &mut Context<Self>) {
+        self.sync_broadcast_label(title, cx);
+    }
+
     fn sidebar_contributions(&self, _cx: &App) -> Vec<SidebarContribution> {
         Vec::new()
     }

--- a/crates/terminal_view/src/workspace/tab_content.rs
+++ b/crates/terminal_view/src/workspace/tab_content.rs
@@ -88,6 +88,12 @@ impl TabContent for TerminalWorkspace {
         }
     }
 
+    fn apply_title(&mut self, title: &str, _window: &mut Window, cx: &mut Context<Self>) {
+        self.active_pane().update(cx, |pane, cx| {
+            pane.sync_broadcast_label(title, cx);
+        });
+    }
+
     fn sidebar_contributions(&self, _cx: &App) -> Vec<SidebarContribution> {
         Vec::new()
     }

--- a/main/src/home/home_tabs.rs
+++ b/main/src/home/home_tabs.rs
@@ -15,6 +15,7 @@ use notes::NotesView;
 use one_core::license::Feature;
 use one_core::settings::{LocalTerminalCustomProfile, LocalTerminalProfileKind};
 use one_core::storage::{ConnectionType, StoredConnection, Workspace};
+use one_core::tab_actions::next_duplicate_tab_index;
 use one_core::tab_container::{TabContainer, TabItem, TabOpenMode};
 use redis_view::RedisTabView;
 use remote_desktop::{RemoteDesktopConnectionOptions, RemoteDesktopProtocol};
@@ -873,6 +874,18 @@ impl HomePage {
         });
     }
 
+    /// 计算同基础名称的下一个可用标签序号；没有任何同名标签时返回 None（首标签不加序号）。
+    fn next_available_tab_index(&self, base_title: &str, cx: &App) -> Option<usize> {
+        let tab_container = self.active_tab_container(cx);
+        let titles: Vec<String> = tab_container
+            .read(cx)
+            .tabs()
+            .iter()
+            .map(|tab| tab.title(cx).to_string())
+            .collect();
+        next_duplicate_tab_index(base_title, titles.iter().map(String::as_str))
+    }
+
     fn terminal_sync_path_enabled(cx: &App) -> bool {
         current_terminal_settings(cx).sync_path_with_terminal
     }
@@ -901,7 +914,7 @@ impl HomePage {
             .unwrap_or(0);
         let tab_id = format!("ssh-terminal-{}-{}", conn_id, timestamp);
 
-        // 统计同一连接的 SSH 终端数量，计算序号
+        // 统计同一连接的 SSH 终端数量，计算序号（从 (1) 开始，复用已释放序号）
         let prefix = format!("ssh-terminal-{}-", conn_id);
         let tab_container = self.active_tab_container(cx);
         let existing_count = tab_container
@@ -910,11 +923,10 @@ impl HomePage {
             .iter()
             .filter(|t| t.id().starts_with(&prefix))
             .count();
-        let tab_index = if existing_count > 0 {
-            Some(existing_count + 1)
-        } else {
-            None
-        };
+        let base_title = conn.name.clone();
+        let tab_index = self
+            .next_available_tab_index(&base_title, cx)
+            .or_else(|| (existing_count > 0).then_some(existing_count));
         let sync_path = Self::terminal_sync_path_enabled(cx);
 
         let terminal_view = cx.new(|cx| {
@@ -959,11 +971,10 @@ impl HomePage {
             .iter()
             .filter(|t| t.id().starts_with(&prefix))
             .count();
-        let tab_index = if existing_count > 0 {
-            Some(existing_count + 1)
-        } else {
-            None
-        };
+        let base_title = conn.name.clone();
+        let tab_index = self
+            .next_available_tab_index(&base_title, cx)
+            .or_else(|| (existing_count > 0).then_some(existing_count));
 
         let terminal_view =
             cx.new(|cx| TerminalWorkspace::new_serial_with_index(conn, tab_index, window, cx));
@@ -1036,7 +1047,7 @@ impl HomePage {
             .unwrap_or(0);
         let tab_id = format!("sftp-{}-{}", conn_id, timestamp);
 
-        // 统计同一连接的 SFTP 视图数量，计算序号
+        // 统计同一连接的 SFTP 视图数量，计算序号（从 (1) 开始，复用已释放序号）
         let prefix = format!("sftp-{}-", conn_id);
         let tab_container = self.active_tab_container(cx);
         let existing_count = tab_container
@@ -1045,11 +1056,10 @@ impl HomePage {
             .iter()
             .filter(|t| t.id().starts_with(&prefix))
             .count();
-        let tab_index = if existing_count > 0 {
-            Some(existing_count + 1)
-        } else {
-            None
-        };
+        let base_title = conn.name.clone();
+        let tab_index = self
+            .next_available_tab_index(&base_title, cx)
+            .or_else(|| (existing_count > 0).then_some(existing_count));
 
         // 创建 SftpView 并订阅终端打开事件
         let sftp_view = cx.new(|cx| SftpView::new_with_index(conn, tab_index, window, cx));
@@ -1111,7 +1121,7 @@ impl HomePage {
                         let conn_id = connection.id.unwrap_or(0);
                         let tab_id = format!("ssh-terminal-{}-{}", conn_id, ts);
                         let conn = connection.clone();
-                        // 统计同一连接的 SSH 终端数量
+                        // 统计同一连接的 SSH 终端数量，计算序号（从 (1) 开始，复用已释放序号）
                         let prefix = format!("ssh-terminal-{}-", conn_id);
                         let existing = event_tab_container
                             .read(cx)
@@ -1119,11 +1129,18 @@ impl HomePage {
                             .iter()
                             .filter(|t| t.id().starts_with(&prefix))
                             .count();
-                        let idx = if existing > 0 {
-                            Some(existing + 1)
-                        } else {
-                            None
-                        };
+                        let base_title = conn.name.clone();
+                        let titles: Vec<String> = event_tab_container
+                            .read(cx)
+                            .tabs()
+                            .iter()
+                            .map(|tab| tab.title(cx).to_string())
+                            .collect();
+                        let idx = next_duplicate_tab_index(
+                            &base_title,
+                            titles.iter().map(String::as_str),
+                        )
+                        .or_else(|| (existing > 0).then_some(existing));
                         let sync_path = HomePage::terminal_sync_path_enabled(cx);
                         let terminal_view = cx.new(|cx| {
                             TerminalWorkspace::new_ssh_with_index(
@@ -1188,11 +1205,10 @@ impl HomePage {
             .iter()
             .filter(|tab| tab.id().starts_with(&prefix))
             .count();
-        let tab_index = if existing_count > 0 {
-            Some(existing_count + 1)
-        } else {
-            None
-        };
+        let base_title = conn.name.clone();
+        let tab_index = self
+            .next_available_tab_index(&base_title, cx)
+            .or_else(|| (existing_count > 0).then_some(existing_count));
         let title = conn.name.clone();
         let window_handle = window.window_handle();
         let view = cx.new(move |cx| {
@@ -1577,7 +1593,7 @@ impl HomePage {
             .unwrap_or(0);
         let tab_id = format!("terminal-{}", timestamp);
 
-        // 统计已有本地终端数量，计算序号
+        // 统计已有本地终端数量，计算序号（从 (1) 开始，复用已释放序号）
         let tab_container = self.active_tab_container(cx);
         let existing_count = tab_container
             .read(cx)
@@ -1585,11 +1601,9 @@ impl HomePage {
             .iter()
             .filter(|t| t.id().starts_with("terminal-") || t.id().starts_with("local-terminal-"))
             .count();
-        let tab_index = if existing_count > 0 {
-            Some(existing_count + 1)
-        } else {
-            None
-        };
+        let tab_index = self
+            .next_available_tab_index("Terminal", cx)
+            .or_else(|| (existing_count > 0).then_some(existing_count));
 
         let home = cx.entity();
         window.defer(cx, move |window, cx| {


### PR DESCRIPTION
- 复制标签自动追加序号（192.168.1.1 -> 192.168.1.1(1)），复用已释放编号
- 新增 TabContent::apply_title 回调，广播输入面板标签同步
- SSH/SFTP/数据库/本地终端标签统一使用 next_duplicate_tab_index
- 标签宽度按内容自适应，不截断长标题

Closes #[issue number]

## Description

Describe in English for the changes made in this pull request and the problem it solves.
Please keep **1 PR to solve 1 problem**, and keep **Small improvements should be small modifications** to make PR easier to review and to merge.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| [Put Before Screenshot here] | [Put After Screenshot here] |

## Break Changes

Describe any breaking changes introduced by this pull request. If none, remove this section.

- Change 1

```diff
- Old code snippet
+ New code snippet
```

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
