### PR TITLE
feat(workspace): sort connections and workspaces naturally with IP-aw…

### DIFF
--- a/main/src/connection_sort.rs
+++ b/main/src/connection_sort.rs
@@ -1,0 +1,118 @@
+use std::cmp::Ordering;
+use std::iter::Peekable;
+use std::str::Chars;
+
+/// 连接名称排序比较：数字段按数值比较（对 IP 地址友好，如 "172.29.13.2" < "172.29.13.100"），
+/// 其余部分按字符比较（忽略大小写）。
+pub(crate) fn connection_name_cmp(left: &str, right: &str) -> Ordering {
+    natural_cmp(left, right)
+}
+
+fn natural_cmp(left: &str, right: &str) -> Ordering {
+    let mut left_chars = left.chars().peekable();
+    let mut right_chars = right.chars().peekable();
+    loop {
+        match (left_chars.peek().copied(), right_chars.peek().copied()) {
+            (None, None) => return Ordering::Equal,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (Some(left), Some(right)) if left.is_ascii_digit() && right.is_ascii_digit() => {
+                match compare_number_runs(&mut left_chars, &mut right_chars) {
+                    Ordering::Equal => {}
+                    other => return other,
+                }
+            }
+            (Some(left), Some(right)) => {
+                match left.to_ascii_lowercase().cmp(&right.to_ascii_lowercase()) {
+                    Ordering::Equal => {}
+                    other => return other,
+                }
+                left_chars.next();
+                right_chars.next();
+            }
+        }
+    }
+}
+
+/// 比较两个连续数字段（如 IP 段 "2" 与 "100"），按数值大小比较。
+fn compare_number_runs(
+    left: &mut Peekable<Chars<'_>>,
+    right: &mut Peekable<Chars<'_>>,
+) -> Ordering {
+    let left_run = take_number_run(left);
+    let right_run = take_number_run(right);
+    left_run
+        .len
+        .cmp(&right_run.len)
+        .then(left_run.value.cmp(&right_run.value))
+}
+
+fn take_number_run(chars: &mut Peekable<Chars<'_>>) -> NumberRun {
+    let mut len = 0usize;
+    let mut value = 0u128;
+    while let Some(&digit) = chars.peek() {
+        if !digit.is_ascii_digit() {
+            break;
+        }
+        len += 1;
+        value = value
+            .saturating_mul(10)
+            .saturating_add(u128::from(digit.to_digit(10).unwrap_or(0)));
+        chars.next();
+    }
+    NumberRun { len, value }
+}
+
+struct NumberRun {
+    len: usize,
+    value: u128,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sorted(mut names: Vec<&str>) -> Vec<&str> {
+        names.sort_by(|left, right| connection_name_cmp(left, right));
+        names
+    }
+
+    #[test]
+    fn ip_addresses_sort_numerically_by_segment() {
+        let names = sorted(vec![
+            "172.29.13.100",
+            "172.29.13.2",
+            "172.29.9.1",
+            "172.29.13.200",
+        ]);
+
+        assert_eq!(
+            vec![
+                "172.29.9.1",
+                "172.29.13.2",
+                "172.29.13.100",
+                "172.29.13.200"
+            ],
+            names,
+        );
+    }
+
+    #[test]
+    fn hostnames_with_numbers_sort_naturally() {
+        let names = sorted(vec!["host-10", "host-2", "host-1"]);
+
+        assert_eq!(vec!["host-1", "host-2", "host-10"], names);
+    }
+
+    #[test]
+    fn plain_names_sort_lexically_case_insensitive() {
+        let names = sorted(vec!["Redis", "db-server", "App Server", "Db-Server"]);
+
+        assert_eq!(vec!["App Server", "db-server", "Db-Server", "Redis"], names);
+    }
+
+    #[test]
+    fn identical_names_are_equal() {
+        assert_eq!(Ordering::Equal, connection_name_cmp("db-1", "db-1"));
+    }
+}

--- a/main/src/home/home_tabs.rs
+++ b/main/src/home/home_tabs.rs
@@ -46,6 +46,9 @@ fn redis_tab_open_context(
                 .filter(|connection| connection.workspace_id == Some(id))
                 .cloned()
                 .collect();
+            connections.sort_by(|left, right| {
+                crate::connection_sort::connection_name_cmp(&left.name, &right.name)
+            });
             if connections.is_empty() {
                 connections.push(conn.clone());
             }
@@ -1278,13 +1281,16 @@ impl HomePage {
 
         let (tab_id, connections, workspace_for_tab) = match open_mode {
             DatabaseOpenMode::Workspace if workspace_id.is_some() => {
-                let connections = self
+                let mut connections: Vec<StoredConnection> = self
                     .connections
                     .iter()
                     .filter(|connection| connection.workspace_id == workspace_id)
                     .filter(|connection| connection.connection_type == ConnectionType::MongoDB)
                     .cloned()
                     .collect();
+                connections.sort_by(|left, right| {
+                    crate::connection_sort::connection_name_cmp(&left.name, &right.name)
+                });
                 let tab_id = format!("workspace-mongodb-tab-{}", workspace_id.unwrap_or(0));
                 (tab_id, connections, workspace)
             }
@@ -1622,7 +1628,7 @@ impl HomePage {
         // 在 defer 之前准备所有需要的数据，避免在 HomePage 更新期间
         // 触发 on_deactivate 导致双重借用 panic
         let workspace_id = workspace.as_ref().and_then(|w| w.id);
-        let Some((conn_clone, connections)) = database_tab_connection_context(
+        let Some((conn_clone, mut connections)) = database_tab_connection_context(
             open_mode,
             conn,
             workspace_id,
@@ -1631,6 +1637,10 @@ impl HomePage {
         ) else {
             return;
         };
+        // 分组内的连接按名称排序（IP 地址按数值段比较）
+        connections.sort_by(|left, right| {
+            crate::connection_sort::connection_name_cmp(&left.name, &right.name)
+        });
 
         let tab_container = self.active_tab_container(cx);
         window.defer(cx, move |window, cx| {

--- a/main/src/home_tab/content.rs
+++ b/main/src/home_tab/content.rs
@@ -54,7 +54,7 @@ impl HomePage {
                 }
             })
             .map(|ws| {
-                let conn_list: Vec<_> = self
+                let mut conn_list: Vec<_> = self
                     .connections
                     .iter()
                     .filter(|conn| conn.workspace_id == ws.id)
@@ -62,11 +62,15 @@ impl HomePage {
                     .filter(|conn| self.match_connection_type(conn))
                     .cloned()
                     .collect();
+                // 分组内的连接按名称排序（IP 地址按数值段比较）
+                conn_list.sort_by(|left, right| {
+                    crate::connection_sort::connection_name_cmp(&left.name, &right.name)
+                });
                 (ws.clone(), conn_list)
             })
             .collect();
 
-        let unassigned_connections: Vec<_> = self
+        let mut unassigned_connections: Vec<_> = self
             .connections
             .iter()
             .filter(|conn| conn.workspace_id.is_none())
@@ -74,6 +78,9 @@ impl HomePage {
             .filter(|conn| self.match_connection_type(conn))
             .cloned()
             .collect();
+        unassigned_connections.sort_by(|left, right| {
+            crate::connection_sort::connection_name_cmp(&left.name, &right.name)
+        });
         let has_workspaces = self.workspaces.iter().any(|ws| ws.id.is_some());
 
         if layout == ConnectionLayout::List && !has_workspaces {

--- a/main/src/home_tab/data.rs
+++ b/main/src/home_tab/data.rs
@@ -13,7 +13,10 @@ impl HomePage {
         });
 
         cx.spawn(async move |this, cx: &mut AsyncApp| match load_task.await {
-            Ok(workspaces) => {
+            Ok(mut workspaces) => {
+                workspaces.sort_by(|left, right| {
+                    crate::connection_sort::connection_name_cmp(&left.name, &right.name)
+                });
                 _ = this.update(cx, |this, cx| {
                     this.workspaces = workspaces;
                     cx.notify();

--- a/main/src/home_tab/workspace.rs
+++ b/main/src/home_tab/workspace.rs
@@ -113,6 +113,9 @@ impl HomePage {
                         );
                     } else {
                         this.workspaces.push(workspace);
+                        this.workspaces.sort_by(|left, right| {
+                            crate::connection_sort::connection_name_cmp(&left.name, &right.name)
+                        });
                         emit_connection_event(
                             ConnectionDataEvent::WorkspaceCreated { workspace_id },
                             cx,

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -10,6 +10,7 @@ mod auth;
 
 mod ai_chat_acp;
 mod app_init;
+mod connection_sort;
 mod connection_visuals;
 mod credential_vault;
 mod env_file;

--- a/main/src/persistent_connection_sidebar/tree.rs
+++ b/main/src/persistent_connection_sidebar/tree.rs
@@ -104,6 +104,10 @@ impl PersistentConnectionSidebar {
                 })
             })
             .collect::<Vec<_>>();
+        // 分组内的连接按名称排序（IP 地址按数值段比较）
+        connections.sort_by(|left, right| {
+            crate::connection_sort::connection_name_cmp(&left.name, &right.name)
+        });
         filter_connection_tree_inputs(&mut workspaces, &mut connections, &query, |connection| {
             matching_connection_ids.contains(&connection.id)
         });


### PR DESCRIPTION
…are ordering

- 首页工作区分组、未分组连接与持久侧栏连接树按名称自然排序
- IP 各段按数值比较（10.0.0.2 < 10.0.0.10），忽略大小写
- workspace 加载与新建后同步排序
- 新增 main/src/connection_sort.rs 提供自然排序比较函数

Closes #[issue number]

## Description

Describe in English for the changes made in this pull request and the problem it solves.
Please keep **1 PR to solve 1 problem**, and keep **Small improvements should be small modifications** to make PR easier to review and to merge.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| [Put Before Screenshot here] | [Put After Screenshot here] |

## Break Changes

Describe any breaking changes introduced by this pull request. If none, remove this section.

- Change 1

```diff
- Old code snippet
+ New code snippet
```

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
