### PR TITLE
fix(sidebar): keep connection tree floating without shifting tab bar

### DIFF
--- a/crates/core/src/tab_container.rs
+++ b/crates/core/src/tab_container.rs
@@ -3424,44 +3424,72 @@ impl TabContainer {
             return content;
         }
 
-        let center_content = div()
-            .relative()
-            .size_full()
-            .min_w_0()
-            .min_h_0()
-            .overflow_hidden()
-            .child(content)
-            .child(self.render_hidden_sidebar_launcher(hidden, cx));
-        let center = if bottom.is_empty() {
-            center_content.into_any_element()
+        // 中心内容（终端）总是在左右导航浮层之间铺开：导航面板以绝对定位浮动，
+        // 不进入 flex 流，因此标签栏不会被挤动；中心内容向左/右让出面板宽度，
+        // 既保持浮动（不影响标签栏），又不被面板遮挡。
+        let left_width = if left.is_empty() {
+            Pixels::ZERO
         } else {
-            v_flex()
-                .id("tab-sidebar-center")
-                .size_full()
+            self.sidebar_side_width(&left, layout)
+        };
+        let right_width = if right.is_empty() {
+            Pixels::ZERO
+        } else {
+            self.sidebar_side_width(&right, layout)
+        };
+        let center = if bottom.is_empty() {
+            div()
+                .absolute()
+                .top_0()
+                .bottom_0()
+                .left(left_width)
+                .right(right_width)
+                .min_w_0()
+                .min_h_0()
+                .overflow_hidden()
+                .child(content)
+                .child(self.render_hidden_sidebar_launcher(hidden, cx))
+                .into_any_element()
+        } else {
+            div()
+                .absolute()
+                .top_0()
+                .bottom_0()
+                .left(left_width)
+                .right(right_width)
                 .min_w_0()
                 .min_h_0()
                 .overflow_hidden()
                 .child(
-                    div()
-                        .flex_1()
-                        .min_h_0()
+                    v_flex()
+                        .id("tab-sidebar-center")
+                        .size_full()
                         .min_w_0()
+                        .min_h_0()
                         .overflow_hidden()
-                        .child(center_content),
-                )
-                .child(
-                    div()
-                        .relative()
-                        .w_full()
-                        .h(self.sidebar_bottom_height(&bottom, layout))
-                        .flex_shrink_0()
-                        .overflow_hidden()
-                        .child(self.render_sidebar_dock(SidebarPlacement::Bottom, bottom, cx)),
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_h_0()
+                                .min_w_0()
+                                .overflow_hidden()
+                                .child(content)
+                                .child(self.render_hidden_sidebar_launcher(hidden, cx)),
+                        )
+                        .child(
+                            div()
+                                .relative()
+                                .w_full()
+                                .h(self.sidebar_bottom_height(&bottom, layout))
+                                .flex_shrink_0()
+                                .overflow_hidden()
+                                .child(self.render_sidebar_dock(SidebarPlacement::Bottom, bottom, cx)),
+                        ),
                 )
                 .into_any_element()
         };
 
-        let mut root = h_flex()
+        let mut root = div()
             .id("tab-sidebar-root")
             .relative()
             .size_full()
@@ -3476,34 +3504,32 @@ impl TabContainer {
                     });
                 }
             });
+        root = root.child(center);
         if !left.is_empty() {
+            let left_width = self.sidebar_side_width(&left, layout);
             root = root.child(
                 div()
-                    .relative()
-                    .h_full()
-                    .w(self.sidebar_side_width(&left, layout))
-                    .flex_shrink_0()
+                    .absolute()
+                    .top_0()
+                    .bottom_0()
+                    .left_0()
+                    .w(left_width)
                     .overflow_hidden()
+                    .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| cx.stop_propagation())
                     .child(self.render_sidebar_dock(SidebarPlacement::Left, left, cx)),
             );
         }
-        root = root.child(
-            div()
-                .flex_1()
-                .h_full()
-                .min_w_0()
-                .min_h_0()
-                .overflow_hidden()
-                .child(center),
-        );
         if !right.is_empty() {
+            let right_width = self.sidebar_side_width(&right, layout);
             root = root.child(
                 div()
-                    .relative()
-                    .h_full()
-                    .w(self.sidebar_side_width(&right, layout))
-                    .flex_shrink_0()
+                    .absolute()
+                    .top_0()
+                    .bottom_0()
+                    .right_0()
+                    .w(right_width)
                     .overflow_hidden()
+                    .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| cx.stop_propagation())
                     .child(self.render_sidebar_dock(SidebarPlacement::Right, right, cx)),
             );
         }
@@ -3613,9 +3639,12 @@ impl TabContainer {
         let tab_bar_height = layout.tab_bar;
         let tab_item_height = layout.tab_item;
 
-        // When the application navigation sidebar is fully hidden on macOS,
-        // reserve the title-bar area occupied by the traffic-light controls.
-        if titlebar_platform.is_macos && navigation_sidebar_expanded == Some(false) {
+        // On macOS reserve the title-bar area occupied by the traffic-light
+        // controls. The navigation sidebar now floats (absolute) instead of
+        // pushing the tab bar, so the reservation must stay constant in both
+        // the collapsed and expanded states; otherwise the toggle button
+        // jumps left when toggled.
+        if titlebar_platform.is_macos && navigation_sidebar_expanded.is_some() {
             left_padding = layout.macos_compact_title_bar_content_padding;
         }
 

--- a/main/src/onetcli_app.rs
+++ b/main/src/onetcli_app.rs
@@ -1977,7 +1977,7 @@ mod tests {
         assert!(render.contains(".when(show_persistent_sidebar"));
         assert!(render.contains("layout.child(self.connection_sidebar.clone())"));
         assert!(sidebar_source.contains("fn is_expanded"));
-        assert!(sidebar_source.contains(".when(self.tree_expanded"));
+        assert!(sidebar_source.contains("fn render_floating_tree"));
     }
 
     #[test]
@@ -2452,6 +2452,15 @@ impl Render for OnetCliApp {
         let dialog_layer = Root::render_dialog_layer(window, cx);
         let notification_layer = Root::render_notification_layer(window, cx);
         let main_content = self.render_main_content(cx);
+        let show_persistent_sidebar = self.home_page_style.uses_persistent_sidebar();
+        let sidebar_expanded = self.connection_sidebar.read(cx).is_expanded();
+        let floating_tree = if show_persistent_sidebar && sidebar_expanded {
+            Some(self.connection_sidebar.update(cx, |sidebar, cx| {
+                sidebar.render_floating_tree(window, cx)
+            }))
+        } else {
+            None
+        };
         div()
             .size_full()
             .relative()
@@ -2477,7 +2486,6 @@ impl Render for OnetCliApp {
             }))
             .bg(cx.theme().background)
             .child({
-                let show_persistent_sidebar = self.home_page_style.uses_persistent_sidebar();
                 gpui_component::h_flex()
                     .size_full()
                     .min_w_0()
@@ -2485,7 +2493,32 @@ impl Render for OnetCliApp {
                     .when(show_persistent_sidebar, |layout| {
                         layout.child(self.connection_sidebar.clone())
                     })
-                    .child(div().flex_1().min_w_0().h_full().child(main_content))
+                    .child(
+                    div()
+                        .flex_1()
+                        .min_w_0()
+                        .h_full()
+                        .when(show_persistent_sidebar && sidebar_expanded, |this| {
+                            this.on_mouse_down(
+                                gpui::MouseButton::Left,
+                                cx.listener(|this, event: &gpui::MouseDownEvent, _window, cx| {
+                                    if !this.connection_sidebar.read(cx).is_expanded() {
+                                        return;
+                                    }
+                                    let layout = cx.theme().geometry.layout;
+                                    let in_terminal = event.position.x > layout.global_rail
+                                        && event.position.y > layout.tab_bar;
+                                    if in_terminal {
+                                        this.set_connection_sidebar_expanded(false, cx);
+                                    }
+                                }),
+                            )
+                        })
+                        .child(main_content),
+                    )
+            })
+            .when(show_persistent_sidebar && sidebar_expanded, |this| {
+                this.child(floating_tree.unwrap())
             })
             .children(sheet_layer)
             .children(dialog_layer)

--- a/main/src/persistent_connection_sidebar/mod.rs
+++ b/main/src/persistent_connection_sidebar/mod.rs
@@ -1,7 +1,6 @@
-use gpui::prelude::FluentBuilder as _;
 use gpui::{
-    AppContext, Context, Entity, EventEmitter, Hsla, IntoElement, ParentElement, Pixels, Render,
-    Styled, UniformListScrollHandle, Window,
+    AnyElement, AppContext, Context, Entity, EventEmitter, Hsla, InteractiveElement, IntoElement,
+    ParentElement, Pixels, Render, Styled, UniformListScrollHandle, Window, div,
 };
 use gpui_component::{
     ActiveTheme as _, h_flex,
@@ -123,6 +122,31 @@ pub(crate) enum PersistentConnectionSidebarEvent {
 impl EventEmitter<PersistentConnectionSidebarEvent> for PersistentConnectionSidebar {}
 
 impl PersistentConnectionSidebar {
+    /// Render the connection tree as a floating panel that overlays the main
+    /// content instead of occupying flex space, so expanding it no longer
+    /// squeezes the terminal. The caller (OnetCliApp) positions it just after
+    /// the navigation rail and above the terminal, and collapses it when the
+    /// terminal regains focus.
+    pub(crate) fn render_floating_tree(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let palette = self.palette(cx);
+        let layout = cx.theme().geometry.layout;
+        let rail_width = layout.global_rail;
+        let top = layout.tab_bar;
+        div()
+            .absolute()
+            .top(top)
+            .bottom_0()
+            .left(rail_width)
+            .w(self.tree_width)
+            .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .child(self.render_connection_tree(palette, window, cx))
+            .into_any_element()
+    }
+
     pub(crate) fn new(
         home_page: Entity<HomePage>,
         tree_expanded: bool,
@@ -196,7 +220,7 @@ impl PersistentConnectionSidebar {
 }
 
 impl Render for PersistentConnectionSidebar {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let palette = self.palette(cx);
         h_flex()
             .h_full()
@@ -207,9 +231,6 @@ impl Render for PersistentConnectionSidebar {
                 palette,
                 cx,
             ))
-            .when(self.tree_expanded, |this| {
-                this.child(self.render_connection_tree(palette, window, cx))
-            })
             .into_any_element()
     }
 }


### PR DESCRIPTION
Render the connection tree as an absolute floating panel overlaying the terminal instead of occupying flex space, so expanding it no longer squeezes or pushes the terminal/tab bar.

- Give the floating tree an explicit width so the panel is visible (previously collapsed to zero width and appeared blank).
- Stop event propagation on the floating tree and sidebar docks so clicking a connection no longer bubbles up and collapses the sidebar before the connection opens.
- Keep the macOS traffic-light left padding constant across the collapsed/expanded states so the expand/collapse toggle button no longer jumps left under the window controls when toggled.

Closes #[issue number]

## Description

Describe in English for the changes made in this pull request and the problem it solves.
Please keep **1 PR to solve 1 problem**, and keep **Small improvements should be small modifications** to make PR easier to review and to merge.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| [Put Before Screenshot here] | [Put After Screenshot here] |

## Break Changes

Describe any breaking changes introduced by this pull request. If none, remove this section.

- Change 1

```diff
- Old code snippet
+ New code snippet
```

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
