### PR TITLE
fix(popup-window): place popups on the active window's screen

### DIFF
--- a/crates/core/src/popup_window.rs
+++ b/crates/core/src/popup_window.rs
@@ -1,13 +1,32 @@
 use gpui::{
-    AnyView, App, AppContext, Bounds, Context, InteractiveElement, IntoElement, KeyBinding,
-    ParentElement, Render, SharedString, Size, StatefulInteractiveElement, Styled, Window,
-    WindowBounds, WindowKind, WindowOptions, actions, div, point, prelude::FluentBuilder, px, size,
+    AnyView, AnyWindowHandle, App, AppContext, Bounds, Context, InteractiveElement, IntoElement,
+    KeyBinding, ParentElement, Render, SharedString, Size, StatefulInteractiveElement, Styled,
+    Window, WindowBounds, WindowKind, WindowOptions, actions, div, prelude::FluentBuilder, px,
+    size,
 };
+use std::sync::OnceLock;
 use gpui_component::{
     ActiveTheme, Root, TITLE_BAR_HEIGHT, TitleBar, WindowExt, notification::Notification, v_flex,
 };
 
 const FULLSCREEN_POPUP_CONTEXT: &str = "FullscreenPopupWindow";
+
+/// 主窗口 handle 注册表。
+///
+/// 部分弹出窗口的调用方只持有 `cx: &mut App`、没有 `&mut Window`，而 GPUI 在
+/// 这类上下文里 `cx.active_window()` 会返回 `None`。此时回退到主窗口 handle，
+/// 让弹窗落在用户实际所在的屏幕（主窗口所在显示器）。
+static MAIN_WINDOW_HANDLE: OnceLock<AnyWindowHandle> = OnceLock::new();
+
+/// 由主程序在创建主窗口后注册主窗口 handle。
+pub fn set_main_window_handle(handle: AnyWindowHandle) {
+    let _ = MAIN_WINDOW_HANDLE.set(handle);
+}
+
+/// 读取已注册的主窗口 handle（未注册时返回 `None`）。
+fn main_window_handle() -> Option<AnyWindowHandle> {
+    MAIN_WINDOW_HANDLE.get().copied()
+}
 
 actions!(popup_window, [ExitPopupFullscreen]);
 
@@ -103,9 +122,16 @@ impl PopupWindowOptions {
 /// 异步创建一个独立的弹出窗口，窗口内容由 `create_view_fn` 提供。
 /// 窗口会自动包含 Root 组件以支持 notification 等功能。
 ///
+/// 弹出窗口应出现在「父窗口 / 当前激活窗口」所在的屏幕，而不是恒落主屏幕。
+/// 优先使用 `parent_window`（调用方透传的真实窗口，最可靠）；没有时回退到当前激活窗口；
+/// 再没有则回退主屏幕。`parent_window` 的 display_id 在读取前先 `bounds_changed` 一次，
+/// 刷新「窗口被拖到另一屏但未触发 resize」时 GPUI 未刷新的缓存 `display_id`，
+/// 从而保证弹窗落在真实所在屏幕。
+///
 /// # 参数
 /// - `options`: 窗口配置选项
 /// - `create_view_fn`: 创建窗口内容的闭包
+/// - `parent_window`: 触发弹窗的父窗口；为 `None` 时回退到激活窗口 / 主屏幕
 /// - `cx`: App 上下文
 ///
 /// # 示例
@@ -115,34 +141,63 @@ impl PopupWindowOptions {
 ///     |window, cx| {
 ///         cx.new(|cx| MyView::new(window, cx))
 ///     },
+///     Some(window),
 ///     cx,
 /// );
 /// ```
-pub fn open_popup_window<F, E>(options: PopupWindowOptions, create_view_fn: F, cx: &mut App)
-where
+pub fn open_popup_window<F, E>(
+    options: PopupWindowOptions,
+    create_view_fn: F,
+    parent_window: Option<&mut Window>,
+    cx: &mut App,
+) where
     E: Into<AnyView>,
     F: FnOnce(&mut Window, &mut App) -> E + Send + 'static,
 {
-    let mut window_size = size(px(options.width), px(options.height));
-    let display = if let Some(active_window) = cx.active_window() {
-        active_window
-            .update(cx, |_, window, cx| window.display(cx))
-            .ok()
-            .flatten()
-            .or_else(|| cx.primary_display())
-    } else {
-        cx.primary_display()
+    // 解析父窗口 / 激活窗口所在显示器的 id。
+    let parent_display_id = match parent_window {
+        Some(window) => {
+            window.bounds_changed(cx);
+            window.display(cx).map(|display| display.id())
+        }
+        None => {
+            // 没有父窗口时，优先活动窗口；活动窗口取不到（仅持有 App 上下文的调用方）
+            // 则回退到注册的主窗口 handle，保证弹窗落在用户实际所在屏幕。
+            let from_active = cx.active_window().and_then(|handle| {
+                handle
+                    .update(cx, |_, window, cx| {
+                        window.bounds_changed(cx);
+                        window.display(cx)
+                    })
+                    .ok()
+                    .flatten()
+                    .map(|display| display.id())
+            });
+            from_active.or_else(|| {
+                main_window_handle().and_then(|handle| {
+                    cx.update_window(handle, |_, window, cx| {
+                        window.bounds_changed(cx);
+                        window.display(cx).map(|display| display.id())
+                    })
+                    .ok()
+                    .flatten()
+                })
+            })
+        }
     };
-    let display_id = display.as_ref().map(|display| display.id());
-    let window_bounds = if let Some(display) = display.as_ref() {
-        let display_bounds = display.visible_bounds();
-        let display_size = display_bounds.size;
+
+    let mut window_size = size(px(options.width), px(options.height));
+    let display = parent_display_id
+        .and_then(|id| cx.find_display(id))
+        .or_else(|| cx.primary_display());
+    if let Some(display) = display {
+        let display_size = display.bounds().size;
         window_size.width = window_size.width.min(display_size.width * 0.85);
         window_size.height = window_size.height.min(display_size.height * 0.85);
-        Bounds::centered_at(display_bounds.center(), window_size)
-    } else {
-        Bounds::new(point(px(0.0), px(0.0)), window_size)
-    };
+    }
+    // `Bounds::centered` 生成目标显示器局部坐标的居中 bounds，平台层会再叠加
+    // 该显示器 frame 原点；必须同时指定 display_id。
+    let window_bounds = Bounds::centered(parent_display_id, window_size, cx);
     let title = options.title.clone();
     let fullscreen_hint = options.fullscreen_hint.clone();
 
@@ -159,7 +214,7 @@ where
                 width: px(options.min_width),
                 height: px(options.min_height),
             }),
-            display_id,
+            display_id: parent_display_id,
             kind: WindowKind::Normal,
             window_background: gpui::WindowBackgroundAppearance::Transparent,
             #[cfg(target_os = "linux")]

--- a/crates/core/src/popup_window_tests.rs
+++ b/crates/core/src/popup_window_tests.rs
@@ -66,12 +66,16 @@ fn every_popup_registers_with_the_shared_window_close_router() {
 
 #[test]
 fn popup_uses_the_active_window_display() {
+    let source = include_str!("popup_window.rs");
     let open = popup_open_source();
 
-    assert!(open.contains("cx.active_window()"));
-    assert!(open.contains("window.display(cx)"));
-    assert!(open.contains("cx.primary_display()"));
-    assert!(open.contains("display_id"));
-    assert!(open.contains("display.visible_bounds()"));
-    assert!(open.contains("Bounds::centered_at(display_bounds.center()"));
+    // 弹出窗口必须出现在活动窗口所在屏幕，而不是恒落主屏幕。
+    // 方案：解析活动窗口真实的 display_id（必要时先 bounds_changed 刷新过期缓存），
+    // 用 GPUI 的 `Bounds::centered(display_id, ...)` 生成该屏幕下的居中 bounds，
+    // 并把同一个 display_id 传给 WindowOptions，弹窗即落在活动窗口所在屏幕。
+    assert!(open.contains("parent_window"));
+    assert!(source.contains("window.bounds_changed(cx)"));
+    assert!(source.contains("window.display(cx)"));
+    assert!(open.contains("Bounds::centered(parent_display_id"));
+    assert!(open.contains("display_id: parent_display_id"));
 }

--- a/crates/db_view/src/db_tree_event.rs
+++ b/crates/db_view/src/db_tree_event.rs
@@ -1667,6 +1667,7 @@ impl DatabaseEventHandler {
             PopupWindowOptions::new(t!("Table.import_data_to_table").to_string())
                 .size(900.0, 600.0),
             move |_window, _cx| import_view.clone(),
+            Some(window),
             cx,
         );
     }
@@ -1728,6 +1729,7 @@ impl DatabaseEventHandler {
         open_popup_window(
             PopupWindowOptions::new(t!("ImportExport.export_table").to_string()).size(800.0, 600.0),
             move |_window, _cx| export_view.clone(),
+            Some(window),
             cx,
         );
     }
@@ -4318,6 +4320,7 @@ impl DatabaseEventHandler {
         open_popup_window(
             PopupWindowOptions::new(t!("ImportExport.run_sql_file").to_string()).size(800.0, 520.0),
             move |window, cx| SqlRunView::new(connection_id, database, schema, window, cx),
+            Some(_window),
             cx,
         );
     }
@@ -4393,6 +4396,7 @@ impl DatabaseEventHandler {
                                     cx,
                                 )
                             },
+                            None,
                             cx,
                         );
                     })
@@ -4442,6 +4446,7 @@ impl DatabaseEventHandler {
         open_popup_window(
             PopupWindowOptions::new(title).size(1100.0, 780.0),
             move |_window, _cx| compare_view.clone(),
+            Some(window),
             cx,
         );
     }
@@ -4455,6 +4460,7 @@ impl DatabaseEventHandler {
         open_popup_window(
             PopupWindowOptions::new(title).size(1100.0, 780.0),
             move |_window, _cx| compare_view.clone(),
+            Some(window),
             cx,
         );
     }

--- a/crates/db_view/src/table_data/data_grid.rs
+++ b/crates/db_view/src/table_data/data_grid.rs
@@ -1314,6 +1314,7 @@ impl DataGrid {
             PopupWindowOptions::new(t!("TableDataGrid.export_table").to_string())
                 .size(800.0, 600.0),
             move |_window, _cx| export_view.clone(),
+            Some(window),
             cx,
         );
     }

--- a/crates/extension-runtime/src/extension_action_handler/mod.rs
+++ b/crates/extension-runtime/src/extension_action_handler/mod.rs
@@ -221,6 +221,7 @@ fn open_view(view: PreparedExtensionView, cx: &mut App) -> Result<()> {
                 .expect("validated extension view spec")
             })
         },
+        None,
         cx,
     );
     Ok(())

--- a/crates/extension_view/src/offline_package_dialog.rs
+++ b/crates/extension_view/src/offline_package_dialog.rs
@@ -22,6 +22,7 @@ pub(super) fn show_offline_package_dialog(cx: &mut App) {
     one_core::popup_window::open_popup_window(
         options,
         |_window, cx| cx.new(|cx| OfflinePackageDialogView::new(cx)),
+        None,
         cx,
     );
 }

--- a/crates/remote_file_editor/src/editor_window.rs
+++ b/crates/remote_file_editor/src/editor_window.rs
@@ -89,6 +89,7 @@ pub fn open_remote_file_editor<T: 'static>(
                     register_window_close_handler(window.window_handle(), view.downgrade(), cx);
                     view
                 },
+                None,
                 cx,
             );
 

--- a/crates/remote_image_preview/src/lib.rs
+++ b/crates/remote_image_preview/src/lib.rs
@@ -221,6 +221,7 @@ fn open_remote_image_preview_window(
             .min_width(480.0)
             .min_height(360.0),
         move |_window, cx| cx.new(|_| RemoteImagePreview::new(image)),
+        None,
         cx,
     );
 }

--- a/main/src/app_init.rs
+++ b/main/src/app_init.rs
@@ -15,6 +15,7 @@ pub fn init_window_systems(window: &Window, cx: &mut App) {
     }
 
     let _ = MAIN_WINDOW_HANDLE.set(window.window_handle());
+    one_core::popup_window::set_main_window_handle(window.window_handle());
 
     // 初始化 hotkey
     system_hotkey::register(cx);

--- a/main/src/credential_vault/actions.rs
+++ b/main/src/credential_vault/actions.rs
@@ -56,6 +56,7 @@ impl CredentialVaultView {
             move |window, cx| {
                 cx.new(|cx| CredentialFormWindow::new(existing, storage_manager, view, window, cx))
             },
+            Some(_window),
             cx,
         );
     }

--- a/main/src/home/connection_import_window.rs
+++ b/main/src/home/connection_import_window.rs
@@ -33,14 +33,16 @@ pub(crate) struct ConnectionImportWindow {
 
 pub(crate) fn show_connection_import_window(
     parent: Entity<HomePage>,
-    parent_window: AnyWindowHandle,
+    window: &mut Window,
     cx: &mut App,
 ) {
+    let parent_window = window.window_handle();
     open_popup_window(
         PopupWindowOptions::new(t!("Home.import").to_string()).size(1040.0, 720.0),
         move |window, cx| {
             cx.new(|cx| ConnectionImportWindow::new(parent, parent_window, window, cx))
         },
+        Some(window),
         cx,
     );
 }

--- a/main/src/home/connection_import_window/editor.rs
+++ b/main/src/home/connection_import_window/editor.rs
@@ -70,6 +70,7 @@ impl ConnectionImportWindow {
         open_popup_window(
             PopupWindowOptions::new(t!("Home.import").to_string()).size(700.0, 650.0),
             move |window, cx| cx.new(|cx| ConnectionFormWindow::new(form_config, window, cx)),
+            None,
             cx,
         );
     }
@@ -92,6 +93,7 @@ impl ConnectionImportWindow {
         open_popup_window(
             PopupWindowOptions::new(t!("Home.import").to_string()).size(700.0, 650.0),
             move |window, cx| cx.new(|cx| RedisFormWindow::new(form_config, window, cx)),
+            None,
             cx,
         );
     }
@@ -114,6 +116,7 @@ impl ConnectionImportWindow {
         open_popup_window(
             PopupWindowOptions::new(t!("Home.import").to_string()).size(700.0, 650.0),
             move |window, cx| cx.new(|cx| MongoFormWindow::new(form_config, window, cx)),
+            None,
             cx,
         );
     }
@@ -135,6 +138,7 @@ impl ConnectionImportWindow {
         open_popup_window(
             PopupWindowOptions::new(t!("Home.import").to_string()).size(750.0, 650.0),
             move |window, cx| cx.new(|cx| SshFormWindow::new(form_config, window, cx)),
+            None,
             cx,
         );
     }

--- a/main/src/home/remote_desktop_window.rs
+++ b/main/src/home/remote_desktop_window.rs
@@ -77,6 +77,7 @@ pub(crate) fn open_remote_desktop_fullscreen_window(
             view.read(cx).focus_handle(cx).focus(window, cx);
             view
         },
+        None,
         cx,
     );
 }

--- a/main/src/home_tab/connection_forms.rs
+++ b/main/src/home_tab/connection_forms.rs
@@ -124,6 +124,7 @@ impl HomePage {
         open_popup_window(
             PopupWindowOptions::new(title).size(700.0, popup_height),
             move |window, cx| cx.new(|cx| ConnectionFormWindow::new(config, window, cx)),
+            Some(window),
             cx,
         );
     }
@@ -162,6 +163,7 @@ impl HomePage {
         open_popup_window(
             PopupWindowOptions::new(title).size(700.0, 650.0),
             move |window, cx| cx.new(|cx| SshFormWindow::new(config, window, cx)),
+            Some(_window),
             cx,
         );
     }
@@ -203,6 +205,7 @@ impl HomePage {
         open_popup_window(
             PopupWindowOptions::new(title).size(700.0, 650.0),
             move |window, cx| cx.new(|cx| RedisFormWindow::new(config, window, cx)),
+            Some(_window),
             cx,
         );
     }
@@ -239,6 +242,7 @@ impl HomePage {
         open_popup_window(
             PopupWindowOptions::new(title).size(700.0, 650.0),
             move |window, cx| cx.new(|cx| MongoFormWindow::new(config, window, cx)),
+            Some(_window),
             cx,
         );
     }
@@ -275,6 +279,7 @@ impl HomePage {
         open_popup_window(
             PopupWindowOptions::new(title).size(700.0, 600.0),
             move |window, cx| cx.new(|cx| SerialFormWindow::new(config, window, cx)),
+            Some(_window),
             cx,
         );
     }
@@ -311,6 +316,7 @@ impl HomePage {
         open_popup_window(
             PopupWindowOptions::new(title).size(700.0, 600.0),
             move |window, cx| cx.new(|cx| TelnetFormWindow::new(config, window, cx)),
+            Some(_window),
             cx,
         );
     }

--- a/main/src/home_tab/connection_open.rs
+++ b/main/src/home_tab/connection_open.rs
@@ -73,6 +73,7 @@ impl HomePage {
                     )
                 })
             },
+            Some(window),
             cx,
         );
     }

--- a/main/src/home_tab/forwarding.rs
+++ b/main/src/home_tab/forwarding.rs
@@ -44,6 +44,7 @@ impl HomePage {
         open_popup_window(
             PopupWindowOptions::new(title).size(700.0, 520.0),
             move |window, cx| cx.new(|cx| PortForwardingFormWindow::new(config, window, cx)),
+            Some(_window),
             cx,
         );
     }
@@ -147,6 +148,7 @@ impl HomePage {
         open_popup_window(
             PopupWindowOptions::new(title).size(700.0, 560.0),
             move |window, cx| cx.new(|cx| RemoteDesktopFormWindow::new(config, window, cx)),
+            Some(_window),
             cx,
         );
     }

--- a/main/src/home_tab/modern_home.rs
+++ b/main/src/home_tab/modern_home.rs
@@ -358,7 +358,7 @@ fn render_create_panel(
             view,
             window,
             |_, window, cx| {
-                show_connection_import_window(cx.entity(), window.window_handle(), cx);
+                show_connection_import_window(cx.entity(), window, cx);
             },
             cx,
         ))

--- a/main/src/home_tab/toolbar.rs
+++ b/main/src/home_tab/toolbar.rs
@@ -90,7 +90,7 @@ impl HomePage {
                                 move |_, window, cx| {
                                     show_connection_import_window(
                                         view.clone(),
-                                        window.window_handle(),
+                                        window,
                                         cx,
                                     );
                                 }

--- a/main/src/setting_tab.rs
+++ b/main/src/setting_tab.rs
@@ -2749,6 +2749,7 @@ fn show_global_proxy_settings_window(cx: &mut App) {
         PopupWindowOptions::new(t!("Settings.General.Proxy.dialog_title").to_string())
             .size(560.0, 460.0),
         move |window, cx| cx.new(|cx| GlobalProxySettingsView::new(window, cx)),
+        None,
         cx,
     );
 }

--- a/main/src/update/dialog.rs
+++ b/main/src/update/dialog.rs
@@ -37,6 +37,7 @@ pub(super) fn show_update_dialog(info: UpdateDialogInfo, cx: &mut App) {
         PopupWindowOptions::new(t!("Update.title").to_string())
             .size(AVAILABLE_WINDOW_WIDTH, AVAILABLE_WINDOW_HEIGHT),
         move |_window, cx| cx.new(|cx| UpdateDialogView::new(info, cx)),
+        None,
         cx,
     );
 }


### PR DESCRIPTION
弹窗（如「+新建连接」「导入」、设置、更新、远程桌面、图片预览等）
在主窗口位于副屏时，仍会落在主显示器上。

根因：open_popup_window 依赖 cx.active_window()，但调用上下文中 该值返回 None；且窗口被拖到另一屏而未触发 resize 时，GPUI 缓存的
display_id 不会刷新，导致定位到过期/主屏幕。

修复：
- open_popup_window 新增 parent_window: Option<&mut Window> 参数， 由调用方传入真实窗口以取正确显示器。
- 读取 window.display(cx) 前先调用 window.bounds_changed(cx) 刷新 过期的缓存 display_id，再用 Bounds::centered(display_id, …) 居中， 并向 WindowOptions 传入同一 display_id。
- 新增注册式主窗口 handle 回退（set_main_window_handle，于 app_init 中注册），使仅持有 cx: &mut App 的调用方也能落到用户 所在屏幕。
- 同步更新所有 open_popup_window 调用点及源码契约测试。

Closes #[issue number]

## Description

Describe in English for the changes made in this pull request and the problem it solves.
Please keep **1 PR to solve 1 problem**, and keep **Small improvements should be small modifications** to make PR easier to review and to merge.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| [Put Before Screenshot here] | [Put After Screenshot here] |

## Break Changes

Describe any breaking changes introduced by this pull request. If none, remove this section.

- Change 1

```diff
- Old code snippet
+ New code snippet
```

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
