### PR TITLE
feat(connection-tree): 连接树自动隐藏开关与固定分割面板

### DIFF
--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -747,10 +747,21 @@ fn format_legacy_custom_command(program: &str, arguments: &str) -> String {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConnectionSidebarTreeState {
     #[serde(default)]
     pub hide_empty_workspaces: bool,
+    #[serde(default = "default_true")]
+    pub auto_hide_tree: bool,
+}
+
+impl Default for ConnectionSidebarTreeState {
+    fn default() -> Self {
+        Self {
+            hide_empty_workspaces: false,
+            auto_hide_tree: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/main/locales/main.yml
+++ b/main/locales/main.yml
@@ -1502,6 +1502,10 @@ Connection:
     en: Batch Operations
     zh-CN: 批量操作
     zh-HK: 批量操作
+  auto_hide_tree:
+    en: Auto-hide the tree after opening a session
+    zh-CN: 自动隐藏
+    zh-HK: 自動隱藏
   batch_select_visible:
     en: Select or Deselect Visible Connections
     zh-CN: 选择或取消选择当前可见连接

--- a/main/src/onetcli_app.rs
+++ b/main/src/onetcli_app.rs
@@ -1999,6 +1999,29 @@ mod tests {
     }
 
     #[test]
+    fn auto_hide_off_renders_a_docked_split_panel_instead_of_a_floating_overlay() {
+        let source = include_str!("onetcli_app.rs");
+        let sidebar_source = include_str!("persistent_connection_sidebar/mod.rs");
+        let render = source
+            .rsplit("impl Render for OnetCliApp")
+            .next()
+            .expect("OnetCliApp render source");
+
+        assert!(
+            render.contains("is_auto_hide_tree()"),
+            "主渲染需读取连接树的自动隐藏开关"
+        );
+        assert!(
+            render.contains("render_docked_connection_tree"),
+            "非自动隐藏时应渲染并排的分割面板"
+        );
+        assert!(
+            render.contains("show_persistent_sidebar && sidebar_expanded && auto_hide_tree"),
+            "浮层连接树仅应在自动隐藏开启时渲染，避免遮挡终端"
+        );
+    }
+
+    #[test]
     fn home_style_switches_between_legacy_home_and_modern_persistent_sidebar() {
         let app = include_str!("onetcli_app.rs");
         let home = include_str!("home_tab/render.rs");
@@ -2472,9 +2495,18 @@ impl Render for OnetCliApp {
         let main_content = self.render_main_content(cx);
         let show_persistent_sidebar = self.home_page_style.uses_persistent_sidebar();
         let sidebar_expanded = self.connection_sidebar.read(cx).is_expanded();
-        let floating_tree = if show_persistent_sidebar && sidebar_expanded {
+        let auto_hide_tree = self.connection_sidebar.read(cx).is_auto_hide_tree();
+        let docked_tree = show_persistent_sidebar && sidebar_expanded && !auto_hide_tree;
+        let floating_tree = if show_persistent_sidebar && sidebar_expanded && auto_hide_tree {
             Some(self.connection_sidebar.update(cx, |sidebar, cx| {
                 sidebar.render_floating_tree(window, cx)
+            }))
+        } else {
+            None
+        };
+        let docked_tree_element = if docked_tree {
+            Some(self.connection_sidebar.update(cx, |sidebar, cx| {
+                sidebar.render_docked_connection_tree(window, cx)
             }))
         } else {
             None
@@ -2511,12 +2543,17 @@ impl Render for OnetCliApp {
                     .when(show_persistent_sidebar, |layout| {
                         layout.child(self.connection_sidebar.clone())
                     })
+                    .when_some(docked_tree_element, |layout, tree| {
+                        layout.child(tree)
+                    })
                     .child(
                     div()
                         .flex_1()
                         .min_w_0()
                         .h_full()
-                        .when(show_persistent_sidebar && sidebar_expanded, |this| {
+                        .when(
+                            show_persistent_sidebar && sidebar_expanded && auto_hide_tree,
+                            |this| {
                             this.on_mouse_down(
                                 gpui::MouseButton::Left,
                                 cx.listener(|this, event: &gpui::MouseDownEvent, _window, cx| {
@@ -2535,7 +2572,7 @@ impl Render for OnetCliApp {
                         .child(main_content),
                     )
             })
-            .when(show_persistent_sidebar && sidebar_expanded, |this| {
+            .when(show_persistent_sidebar && sidebar_expanded && auto_hide_tree, |this| {
                 this.child(floating_tree.unwrap())
             })
             .children(sheet_layer)

--- a/main/src/persistent_connection_sidebar/batch_toolbar.rs
+++ b/main/src/persistent_connection_sidebar/batch_toolbar.rs
@@ -1,6 +1,7 @@
-use gpui::{Anchor, AnyElement, IntoElement, ParentElement, Styled, div};
+use gpui::prelude::FluentBuilder as _;
+use gpui::{Anchor, AnyElement, IntoElement, ParentElement, Radians, Styled, div};
 use gpui_component::{
-    Disableable, IconName, Sizable,
+    Disableable, Icon, IconName, IconSize, Sizable,
     button::Toggle,
     button::{IconButton, IconButtonRole},
     h_flex,
@@ -98,6 +99,27 @@ pub(super) fn batch_mode_toggle(
         .tooltip(t!("Connection.batch_operations"))
         .on_click(move |checked, _, cx| {
             view.update(cx, |this, cx| this.set_batch_mode(*checked, cx));
+        })
+}
+
+pub(super) fn auto_hide_tree_toggle(
+    view: gpui::Entity<PersistentConnectionSidebar>,
+    active: bool,
+    palette: SidebarPalette,
+) -> Toggle {
+    // 竖着的图钉表示“固定/置顶”（自动隐藏关闭），横着的图钉（顺时针旋转 90°）
+    // 表示“自动隐藏开启”，钉帽在右、针尖指向左侧。
+    let pin = Icon::new(IconName::Pin)
+        .with_size(IconSize::Small)
+        .when(active, |icon| icon.rotate(Radians(std::f32::consts::FRAC_PI_2)));
+    Toggle::new("persistent-auto-hide-tree")
+        .icon(pin)
+        .checked(active)
+        .xsmall()
+        .text_color(palette.foreground)
+        .tooltip(t!("Connection.auto_hide_tree"))
+        .on_click(move |checked, _, cx| {
+            view.update(cx, |this, cx| this.set_auto_hide_tree(*checked, cx));
         })
 }
 

--- a/main/src/persistent_connection_sidebar/mod.rs
+++ b/main/src/persistent_connection_sidebar/mod.rs
@@ -109,6 +109,7 @@ pub(crate) struct PersistentConnectionSidebar {
     connection_selection: ConnectionSelection,
     pub(super) tree_expanded: bool,
     pub(super) hide_empty_workspaces: bool,
+    pub(super) auto_hide_tree: bool,
     pub(super) search_input: Entity<InputState>,
     tree_width: Pixels,
     terminal_colors: Option<TerminalColors>,
@@ -184,6 +185,7 @@ impl PersistentConnectionSidebar {
             connection_selection: ConnectionSelection::default(),
             tree_expanded,
             hide_empty_workspaces: tree_state.hide_empty_workspaces,
+            auto_hide_tree: tree_state.auto_hide_tree,
             search_input,
             tree_width: cx.theme().geometry.layout.context_sidebar_default,
             terminal_colors: None,
@@ -200,6 +202,19 @@ impl PersistentConnectionSidebar {
 
     pub(crate) fn is_expanded(&self) -> bool {
         self.tree_expanded
+    }
+
+    pub(crate) fn is_auto_hide_tree(&self) -> bool {
+        self.auto_hide_tree
+    }
+
+    /// 非自动隐藏模式下，连接树作为与终端并排的分割面板渲染，而不是浮层。
+    pub(crate) fn render_docked_connection_tree(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        self.render_connection_tree(self.palette(cx), window, cx)
     }
 
     pub(crate) fn set_terminal_colors(

--- a/main/src/persistent_connection_sidebar/rows.rs
+++ b/main/src/persistent_connection_sidebar/rows.rs
@@ -249,11 +249,15 @@ impl PersistentConnectionSidebar {
                     cx.new(|_| drag.clone())
                 })
             })
-            .on_double_click(move |_, window, cx| {
-                if let Some(connection) = open_connection.as_ref() {
-                    home_for_open.update(cx, |home, cx| {
-                        home.open_connection_from_quick(connection, window, cx)
-                    });
+            .on_double_click({
+                let view_for_collapse = view_for_select.clone();
+                move |_, window, cx| {
+                    if let Some(connection) = open_connection.as_ref() {
+                        home_for_open.update(cx, |home, cx| {
+                            home.open_connection_from_quick(connection, window, cx)
+                        });
+                    }
+                    view_for_collapse.update(cx, |this, cx| this.collapse_after_open(cx));
                 }
             })
             .on_click(move |event, _, cx| {
@@ -295,5 +299,17 @@ impl PersistentConnectionSidebar {
             .child(tree_label(name))
             .when_some(team_indicator, |row, indicator| row.child(indicator))
             .into_any_element()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn double_click_opening_a_connection_collapses_the_tree_when_auto_hide_is_on() {
+        let source = include_str!("rows.rs");
+        assert!(
+            source.contains("collapse_after_open"),
+            "双击打开会话后应通过 collapse_after_open 触发自动隐藏"
+        );
     }
 }

--- a/main/src/persistent_connection_sidebar/state.rs
+++ b/main/src/persistent_connection_sidebar/state.rs
@@ -1,6 +1,6 @@
 use one_core::settings::{AppSettings, ConnectionSidebarTreeState};
 
-use super::PersistentConnectionSidebar;
+use super::{PersistentConnectionSidebar, PersistentConnectionSidebarEvent};
 
 impl PersistentConnectionSidebar {
     pub(super) fn set_workspace_collapsed(
@@ -48,6 +48,24 @@ impl PersistentConnectionSidebar {
         }
     }
 
+    pub(super) fn set_auto_hide_tree(&mut self, auto_hide: bool, cx: &mut gpui::Context<Self>) {
+        if self.auto_hide_tree != auto_hide {
+            self.auto_hide_tree = auto_hide;
+            self.persist_tree_state(cx);
+            cx.notify();
+        }
+    }
+
+    /// 双击打开会话后，若开启了自动隐藏，则把连接树收起。
+    pub(super) fn collapse_after_open(&mut self, cx: &mut gpui::Context<Self>) {
+        if self.auto_hide_tree && self.tree_expanded {
+            self.set_tree_expanded(false, cx);
+            cx.emit(PersistentConnectionSidebarEvent::TreeVisibilityChanged {
+                expanded: false,
+            });
+        }
+    }
+
     pub(super) fn collapse_all_groups(&mut self, cx: &mut gpui::Context<Self>) {
         self.home_page.update(cx, |home, cx| {
             home.set_all_workspaces_sidebar_collapsed(true, cx);
@@ -55,16 +73,20 @@ impl PersistentConnectionSidebar {
     }
 
     fn persist_tree_state(&self, cx: &mut gpui::Context<Self>) {
-        let tree_state = stored_tree_state(self.hide_empty_workspaces);
+        let tree_state = stored_tree_state(self.hide_empty_workspaces, self.auto_hide_tree);
         AppSettings::update_and_save(cx, |settings| {
             settings.connection_sidebar_tree_state = tree_state;
         });
     }
 }
 
-fn stored_tree_state(hide_empty_workspaces: bool) -> ConnectionSidebarTreeState {
+fn stored_tree_state(
+    hide_empty_workspaces: bool,
+    auto_hide_tree: bool,
+) -> ConnectionSidebarTreeState {
     ConnectionSidebarTreeState {
         hide_empty_workspaces,
+        auto_hide_tree,
     }
 }
 
@@ -74,8 +96,9 @@ mod tests {
 
     #[test]
     fn stored_tree_state_preserves_local_sidebar_preferences() {
-        let state = stored_tree_state(true);
+        let state = stored_tree_state(true, false);
 
         assert!(state.hide_empty_workspaces);
+        assert!(!state.auto_hide_tree);
     }
 }

--- a/main/src/persistent_connection_sidebar/tree.rs
+++ b/main/src/persistent_connection_sidebar/tree.rs
@@ -12,7 +12,7 @@ use rust_i18n::t;
 
 use crate::connection_sort::{connection_name_cmp, lru_sort_key};
 
-use super::batch_toolbar::batch_mode_toggle;
+use super::batch_toolbar::{auto_hide_tree_toggle, batch_mode_toggle};
 use super::tree_model::{
     ConnectionNodeInput, ConnectionTreeRow, WorkspaceNodeInput, build_connection_tree_rows,
     filter_connection_tree_inputs, hide_empty_workspace_inputs,
@@ -248,6 +248,11 @@ impl PersistentConnectionSidebar {
             .child(
                 h_flex()
                     .gap_1()
+                    .child(auto_hide_tree_toggle(
+                        view_for_batch.clone(),
+                        self.auto_hide_tree,
+                        palette,
+                    ))
                     .child(batch_mode_toggle(
                         view_for_batch,
                         self.connection_selection.is_active(),
@@ -277,5 +282,21 @@ mod tests {
         assert!(!implementation.contains("persistent-hide-empty-workspaces"));
         assert!(!implementation.contains("persistent-new-root-group"));
         assert!(!implementation.contains("persistent-refresh-connections"));
+    }
+
+    #[test]
+    fn connection_header_exposes_auto_hide_toggle_left_of_batch_operations() {
+        let source = include_str!("tree.rs");
+        let implementation = source.split("#[cfg(test)]").next().unwrap();
+        let toggle = implementation.find("auto_hide_tree_toggle(").expect(
+            "连接树头部应渲染自动隐藏开关",
+        );
+        let batch = implementation.find("batch_mode_toggle(").expect(
+            "连接树头部应渲染批量操作开关",
+        );
+        assert!(
+            toggle < batch,
+            "自动隐藏开关应位于批量操作开关的左侧"
+        );
     }
 }


### PR DESCRIPTION
- 在连接树头部“批量操作”左侧新增“自动隐藏”开关，状态持久化
- 自动隐藏开启时连接树为浮层，双击打开会话后自动收起
- 自动隐藏关闭时连接树切换为与终端并排的分割面板，避免遮挡终端
- 开关图标：固定用竖图钉，自动隐藏用顺时针旋转 90° 的横图钉

Closes #[issue number]

## Description

Describe in English for the changes made in this pull request and the problem it solves.
Please keep **1 PR to solve 1 problem**, and keep **Small improvements should be small modifications** to make PR easier to review and to merge.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| [Put Before Screenshot here] | [Put After Screenshot here] |

## Break Changes

Describe any breaking changes introduced by this pull request. If none, remove this section.

- Change 1

```diff
- Old code snippet
+ New code snippet
```

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
