### PR TITLE
feat(connection-tree): 自动隐藏模式下点击设置/扩展/AI工作台等非连接区域自动收起连接树

### DIFF
--- a/main/src/persistent_connection_sidebar/navigation_sections.rs
+++ b/main/src/persistent_connection_sidebar/navigation_sections.rs
@@ -32,6 +32,7 @@ pub(super) struct ApplicationSectionConfig {
     pub user_tooltip: String,
     pub palette: SidebarPalette,
     pub item_size: Size,
+    pub sidebar: Entity<PersistentConnectionSidebar>,
 }
 
 #[derive(Clone, Copy)]
@@ -149,9 +150,10 @@ pub(super) fn render_application_buttons(
 ) -> AnyElement {
     let ApplicationSectionConfig {
         availability,
-        user_tooltip,
+        ref user_tooltip,
         palette,
         item_size,
+        ..
     } = config;
     let visuals = ApplicationButtonVisuals { palette, item_size };
     let mut applications = v_flex()
@@ -163,23 +165,25 @@ pub(super) fn render_application_buttons(
         .border_color(palette.border);
     for application in leading_navigation_applications(availability) {
         applications =
-            applications.child(render_application_button(application, home_page, visuals));
+            applications.child(render_application_button(application, home_page, &config, visuals));
     }
-    applications = applications.child(render_application_overflow_button(home_page, visuals));
+    applications = applications.child(render_application_overflow_button(home_page, &config, visuals));
     for application in trailing_navigation_applications() {
         applications =
-            applications.child(render_application_button(application, home_page, visuals));
+            applications.child(render_application_button(application, home_page, &config, visuals));
     }
     applications
-        .child(render_user_button(home_page, user_tooltip, visuals))
+        .child(render_user_button(home_page, user_tooltip.to_string(), visuals))
         .into_any_element()
 }
 
 fn render_application_button(
     application: NavigationApplication,
     home_page: &Entity<HomePage>,
+    config: &ApplicationSectionConfig,
     visuals: ApplicationButtonVisuals,
 ) -> impl IntoElement {
+    let sidebar = config.sidebar.clone();
     rail_button(
         persistent_application_id(application),
         persistent_application_icon(application),
@@ -189,14 +193,17 @@ fn render_application_button(
         visuals.item_size,
         move |home, window, cx| {
             home.activate_navigation_application(application, window, cx);
+            sidebar.update(cx, |sidebar, cx| sidebar.collapse_if_auto_hide(cx));
         },
     )
 }
 
 fn render_application_overflow_button(
     home_page: &Entity<HomePage>,
+    config: &ApplicationSectionConfig,
     visuals: ApplicationButtonVisuals,
 ) -> impl IntoElement {
+    let sidebar = config.sidebar.clone();
     rail_button(
         "persistent-more-applications",
         IconName::Ellipsis,
@@ -204,7 +211,10 @@ fn render_application_overflow_button(
         visuals.palette,
         home_page,
         visuals.item_size,
-        |home, window, cx| home.show_application_navigation_quick_open(window, cx),
+        move |home, window, cx| {
+            home.show_application_navigation_quick_open(window, cx);
+            sidebar.update(cx, |sidebar, cx| sidebar.collapse_if_auto_hide(cx));
+        },
     )
 }
 
@@ -277,5 +287,21 @@ mod tests {
     fn switching_filters_always_reveals_the_connection_tree() {
         assert!(next_tree_expanded_after_filter_click(false, true));
         assert!(next_tree_expanded_after_filter_click(false, false));
+    }
+
+    #[test]
+    fn application_navigation_buttons_auto_collapse_the_connection_tree() {
+        let source = include_str!("navigation_sections.rs");
+        let implementation = source.split("#[cfg(test)]").next().unwrap();
+        let activate = implementation
+            .find("home.activate_navigation_application(application, window, cx)")
+            .expect("应用按钮应触发导航");
+        let collapse = implementation
+            .find("sidebar.collapse_if_auto_hide(cx)")
+            .expect("应用按钮应在导航后自动收起连接树");
+        assert!(
+            activate < collapse,
+            "自动收起逻辑必须紧跟在应用导航之后执行"
+        );
     }
 }

--- a/main/src/persistent_connection_sidebar/rail.rs
+++ b/main/src/persistent_connection_sidebar/rail.rs
@@ -97,7 +97,7 @@ pub(super) fn render_navigation_rail(
                 )
                 .child(render_filter_buttons(
                     home_page,
-                    sidebar,
+                    sidebar.clone(),
                     FilterSectionVisuals {
                         selected_filter,
                         palette,
@@ -114,6 +114,7 @@ pub(super) fn render_navigation_rail(
                         user_tooltip,
                         palette,
                         item_size: rail_item_size,
+                        sidebar: sidebar.clone(),
                     },
                 )),
         )

--- a/main/src/persistent_connection_sidebar/state.rs
+++ b/main/src/persistent_connection_sidebar/state.rs
@@ -66,6 +66,16 @@ impl PersistentConnectionSidebar {
         }
     }
 
+    /// 点击设置、扩展、AI 工作台等非连接区域时，若开启了自动隐藏且连接树已展开，则收起连接树。
+    pub(super) fn collapse_if_auto_hide(&mut self, cx: &mut gpui::Context<Self>) {
+        if self.auto_hide_tree && self.tree_expanded {
+            self.set_tree_expanded(false, cx);
+            cx.emit(PersistentConnectionSidebarEvent::TreeVisibilityChanged {
+                expanded: false,
+            });
+        }
+    }
+
     pub(super) fn collapse_all_groups(&mut self, cx: &mut gpui::Context<Self>) {
         self.home_page.update(cx, |home, cx| {
             home.set_all_workspaces_sidebar_collapsed(true, cx);


### PR DESCRIPTION
- 新增 PersistentConnectionSidebar::collapse_if_auto_hide，仅在 auto_hide_tree 开启且连接树已展开时收起
- 导航栏应用按钮（设置、扩展、AI 工作台等）触发导航后自动收起连接树
- 连接分类筛选按钮保持原有展开/切换行为不变
- 补充 navigation_sections 契约测试

Closes #[issue number]

## Description

Describe in English for the changes made in this pull request and the problem it solves.
Please keep **1 PR to solve 1 problem**, and keep **Small improvements should be small modifications** to make PR easier to review and to merge.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| [Put Before Screenshot here] | [Put After Screenshot here] |

## Break Changes

Describe any breaking changes introduced by this pull request. If none, remove this section.

- Change 1

```diff
- Old code snippet
+ New code snippet
```

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
