### PR TITLE
fix(release): exclude gpui shell from default builds

### DIFF
--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -14,7 +14,7 @@ gpui_platform = { workspace = true }
 gpui-component = { workspace = true, features = ["tree-sitter-bash", "tree-sitter-sql"] }
 gpui-component-assets = { workspace = true }
 gpui-shell = { workspace = true, optional = true }
-gpui-component-shell = { workspace = true }
+gpui-component-shell = { workspace = true, optional = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
@@ -103,7 +103,7 @@ github-distribution = ["github-updates", "github-marketplace"]
 github-marketplace = ["extension-runtime/github-marketplace"]
 github-updates = []
 screenshot-safe = []
-shell-plugins = ["dep:gpui-shell"]
+shell-plugins = ["dep:gpui-shell", "dep:gpui-component-shell"]
 wasm-components = ["extension-runtime/wasm-components"]
 windows-native-rdp = ["remote_desktop_view/windows-native-rdp"]
 

--- a/script/test-release-packaging.mjs
+++ b/script/test-release-packaging.mjs
@@ -262,6 +262,18 @@ test("portable Linux disables WebView while standard builds keep it", () => {
     /embedded-webview = \["ai_chat_view\/embedded-webview"\]/,
   );
   assert.match(
+    mainCargo,
+    /gpui-shell = \{ workspace = true, optional = true \}/,
+  );
+  assert.match(
+    mainCargo,
+    /gpui-component-shell = \{ workspace = true, optional = true \}/,
+  );
+  assert.match(
+    mainCargo,
+    /shell-plugins = \["dep:gpui-shell", "dep:gpui-component-shell"\]/,
+  );
+  assert.match(
     workspaceCargo,
     /ai_chat_view = \{ path = "crates\/ai_chat_view", default-features = false \}/,
   );


### PR DESCRIPTION
## Summary\n\n- make gpui-component-shell optional alongside gpui-shell\n- enable both only through the non-default shell-plugins feature\n- add a release packaging regression contract\n\n## Root cause\n\nThe unconditional gpui-component-shell dependency re-enabled gpui_ce_components_shell and QuickJS transitively, causing the v0.16.0 i686 build to fail in rquickjs-sys.\n\n## Verification\n\n- node --test script/test-release-packaging.mjs\n- python3 script/changelog.py validate --tag v0.16.0 --changelog CHANGELOG.md\n- default i686 dependency graph no longer contains rquickjs-sys\n- --features shell-plugins still contains gpui shell and QuickJS