### PR TITLE
perf(release): use parallel thin LTO builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ on:
           - windows-x64
           - windows-x86
       build_mode:
-        description: "fast 关闭 fat LTO（构建快、体积略大）；release 使用完整 fat LTO"
+        description: "fast 关闭 LTO（构建更快、体积略大）；release 使用 thin LTO"
         required: true
         type: choice
         default: release
@@ -162,7 +162,7 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ matrix.arm_linux && 180 || 120 }}
+    timeout-minutes: ${{ matrix.target == 'aarch64-apple-darwin' && 180 || matrix.arm_linux && 180 || 120 }}
 
     steps:
       - uses: actions/checkout@v7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,8 +301,8 @@ panic = "unwind"
 
 [profile.release]
 opt-level = 3
-lto = "fat"
-codegen-units = 1
+lto = "thin"
+codegen-units = 16
 strip = true
 
 [profile.dev.package]

--- a/script/test-release-packaging.mjs
+++ b/script/test-release-packaging.mjs
@@ -889,16 +889,20 @@ test("Windows release validates the MSI installer with the shared validator", ()
   assert.match(validator, /\$value = \[string\]\$record\.StringData\(1\)/);
 });
 
-test("release builds keep size-optimized Cargo profile defaults", () => {
+test("release builds use parallel thin LTO with a longer macOS ARM timeout", () => {
   const release = read(".github/workflows/release.yml");
   assert.doesNotMatch(release, /^\s+CARGO_PROFILE_RELEASE_LTO:\s/m);
   assert.doesNotMatch(release, /^\s+CARGO_PROFILE_RELEASE_CODEGEN_UNITS:\s/m);
   assert.match(release, /export CARGO_PROFILE_RELEASE_LTO=thin/);
   assert.match(release, /export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16/);
+  assert.match(
+    release,
+    /timeout-minutes: \$\{\{ matrix\.target == 'aarch64-apple-darwin' && 180 \|\| matrix\.arm_linux && 180 \|\| 120 \}\}/,
+  );
 
   const cargo = read("Cargo.toml");
-  assert.match(cargo, /\[profile\.release\][\s\S]*?lto = "fat"/);
-  assert.match(cargo, /\[profile\.release\][\s\S]*?codegen-units = 1/);
+  assert.match(cargo, /\[profile\.release\][\s\S]*?lto = "thin"/);
+  assert.match(cargo, /\[profile\.release\][\s\S]*?codegen-units = 16/);
 });
 
 test("release builds are cacheable and individually repairable", () => {


### PR DESCRIPTION
## Summary\n\n- replace fat LTO / single codegen unit with thin LTO / 16 codegen units\n- raise macOS ARM64 release timeout from 120 to 180 minutes\n- add release workflow regression coverage\n\n## Evidence\n\nThe previous macOS ARM64 build spent the full 120 minutes in cargo build with only 15.9% sccache hits. macOS x64 still took 95m38s with 44% hits.\n\n## Verification\n\n- node --test script/test-release-packaging.mjs\n- python3 script/changelog.py validate --tag v0.16.0 --changelog CHANGELOG.md\n- cargo check -p main --profile release --no-default-features --features wasm-components