### PR TITLE
ai fix it rocky linux 10 kde

### DIFF
--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -1564,14 +1564,47 @@ impl AppSettings {
     pub fn apply(&self, cx: &mut App) {
         gpui_component::set_locale(effective_locale_for_setting(&self.locale));
         crate::themes::apply_appearance(self, cx);
-        self.apply_font_size(cx);
 
         // 同步自动保存配置
         self.sync_auto_save_config(cx);
     }
 
+    /// 将通用字体设置（字号 + 字体族）应用到主题，并同步 GPUI 的 Base 层。
+    ///
+    /// 直接修改 `Theme` 的公共字段不会自动刷新 Base 层副本（滚动条、文本视图
+    /// 默认样式等都从 Base 层读取），因此必须调用 [`Theme::sync_base`] 重建。
+    fn apply_font_settings(&self, cx: &mut App) {
+        let family = self.font_family.trim();
+        // 自定义导入字体（通过 add_fonts 注册）在启动早期尚未进入字体列表，
+        // 因此需额外从 custom_fonts 配置中判定，避免被误判为未安装。
+        let is_custom_font = self.custom_fonts.iter().any(|font| {
+            font.families
+                .iter()
+                .any(|candidate| candidate.trim().eq_ignore_ascii_case(family))
+        });
+        let installed = cx.text_system().all_font_names();
+        let resolved = if family.is_empty()
+            || (!is_custom_font && !is_installed_font_family(family, &installed))
+        {
+            // 未安装的字体族回退到系统 UI 字体，避免渲染异常
+            ".SystemUIFont".to_string()
+        } else {
+            family.to_string()
+        };
+
+        let theme = Theme::global_mut(cx);
+        theme.font_family = resolved.into();
+        theme.font_size = px(self.font_size as f32);
+        Theme::sync_base(cx);
+    }
+
     pub fn apply_font_size(&self, cx: &mut App) {
-        Theme::global_mut(cx).font_size = px(self.font_size as f32);
+        self.apply_font_settings(cx);
+    }
+
+    /// 应用通用字体族设置到主题（设置面板修改"字体"后调用）。
+    pub fn apply_font_family(&self, cx: &mut App) {
+        self.apply_font_settings(cx);
     }
 
     /// 同步自动保存配置到全局状态

--- a/crates/core/src/themes.rs
+++ b/crates/core/src/themes.rs
@@ -157,6 +157,9 @@ pub fn apply_appearance(settings: &AppSettings, cx: &mut App) {
     // additional ring outside the control bounds.
     Theme::global_mut(cx).focus_ring = false;
     apply_custom_accent(settings, cx);
+    // Theme::change 会通过主题配置的 typography 重置 font_family，这里重新应用
+    // 用户配置的通用字体（字号 + 字体族），确保主题切换后字体设置仍生效。
+    settings.apply_font_size(cx);
     cx.refresh_windows();
 }
 

--- a/main/src/setting_tab.rs
+++ b/main/src/setting_tab.rs
@@ -753,6 +753,8 @@ impl SettingsPanel {
                                         AppSettings::update_and_save(cx, |settings| {
                                             settings.font_family = val.to_string();
                                         });
+                                        AppSettings::current(cx).apply_font_family(cx);
+                                        cx.refresh_windows();
                                     },
                                 )
                                 .default_value(SharedString::from(default_settings.font_family)),


### PR DESCRIPTION
Closes #[issue number]

## Description

Blurry fonts in the KDE environment on Rocky Linux 10. AI fix it

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| [<img width="3840" height="2113" alt="Screenshot_20260908_103920" src="https://github.com/user-attachments/assets/57df4846-4f47-4484-92a3-1e8d59ff2f49" />] | [<img width="3840" height="2109" alt="Screenshot_20260908_103803" src="https://github.com/user-attachments/assets/fb8bf309-20be-4938-b4f9-13a3e2a9b0f5" />] |

## Break Changes

Describe any breaking changes introduced by this pull request. If none, remove this section.

- Change 1

```diff
- Old code snippet
+ New code snippet
```

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
