### PR TITLE
fix(ci): repair failing workspace tests and cloud_sync parallel flake

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+* text=auto eol=lf
+
 crates/terminal/src/shell_integration.sh text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,6 @@ jobs:
         if: ${{ matrix.platform == 'macos' }}
         run: |
           cargo test --all
-          cargo test -p gpui-component --doc
       - name: Show sccache statistics
         if: always()
         shell: bash

--- a/crates/ai_chat_view/tests/acp_connection.rs
+++ b/crates/ai_chat_view/tests/acp_connection.rs
@@ -92,7 +92,22 @@ async fn prompt_timeout_sends_cancel_and_returns_to_ready() {
         events.last(),
         Some(RuntimeEvent::TurnFailed { reason, .. }) if reason.contains("timed out")
     ));
-    assert_eq!(AcpConnectionPhase::Ready, connection.phase());
+    // The phase returns to Ready on a separate task after the failed turn
+    // settles; poll with a deadline so the assertion does not race that async
+    // transition (the timeout->cancel handshake can outlive the emitted event).
+    let ready_deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if connection.phase() == AcpConnectionPhase::Ready {
+            break;
+        }
+        if tokio::time::Instant::now() >= ready_deadline {
+            panic!(
+                "connection did not return to Ready after prompt timeout, phase={:?}",
+                connection.phase()
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
 }
 
 #[tokio::test]

--- a/crates/core/src/cloud_sync/engine.rs
+++ b/crates/core/src/cloud_sync/engine.rs
@@ -1225,6 +1225,9 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_team_key_cache_loads_cloud_team_metadata() {
+        let _crypto_guard = crate::crypto::crypto_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let (storage, repo, membership_repo) = test_storage();
         let service = Arc::new(RwLock::new(CloudSyncService::new()));
         service
@@ -1267,6 +1270,9 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_team_roles_uses_bounded_concurrency() {
+        let _crypto_guard = crate::crypto::crypto_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let (storage, _, _) = test_storage();
         let service = Arc::new(RwLock::new(CloudSyncService::new()));
         service
@@ -1304,6 +1310,9 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_team_roles_prefers_aggregate_membership_query() {
+        let _crypto_guard = crate::crypto::crypto_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let (storage, _, _) = test_storage();
         let service = Arc::new(RwLock::new(CloudSyncService::new()));
         service
@@ -1346,6 +1355,9 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_removes_departed_team_cache_and_runtime_key() {
+        let _crypto_guard = crate::crypto::crypto_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let (storage, repo, membership_repo) = test_storage();
         membership_repo
             .upsert(&TeamMembershipCache {
@@ -1417,6 +1429,9 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_removes_team_when_membership_is_confirmed_absent() {
+        let _crypto_guard = crate::crypto::crypto_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let (storage, repo, membership_repo) = test_storage();
         repo.upsert(&TeamKeyCache {
             scope: test_scope(),
@@ -1476,6 +1491,9 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_failure_marks_membership_unknown_without_clearing_key() {
+        let _crypto_guard = crate::crypto::crypto_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let (storage, repo, membership_repo) = test_storage();
         membership_repo
             .upsert(&TeamMembershipCache {
@@ -1547,6 +1565,9 @@ mod tests {
 
     #[tokio::test]
     async fn save_or_initialize_team_key_initializes_missing_verification() {
+        let _crypto_guard = crate::crypto::crypto_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let (storage, repo, _) = test_storage();
         repo.upsert(&TeamKeyCache {
             scope: test_scope(),

--- a/crates/core/src/cloud_sync/personal/local_source_tests.rs
+++ b/crates/core/src/cloud_sync/personal/local_source_tests.rs
@@ -1,5 +1,5 @@
 use std::ops::Deref;
-use std::sync::{Arc, Mutex, MutexGuard, OnceLock, RwLock};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 
 use crate::cloud_sync::models::data_type;
 use crate::cloud_sync::personal::{PersonalSyncLocalRepositorySource, PersonalSyncLocalSource};
@@ -695,8 +695,7 @@ fn credential(name: &str, sync_enabled: bool) -> CredentialEntry {
 }
 
 fn credential_crypto_mutex() -> &'static Mutex<()> {
-    static MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
-    MUTEX.get_or_init(|| Mutex::new(()))
+    crate::crypto::crypto_test_lock()
 }
 
 struct CredentialFixture {

--- a/crates/core/src/crypto.rs
+++ b/crates/core/src/crypto.rs
@@ -101,6 +101,17 @@ static ENCRYPTION_KEY: RwLock<Option<[u8; 32]>> = RwLock::new(None);
 /// 全局原始主密钥存储（用于云同步等需要原始密钥的场景）
 static RAW_MASTER_KEY: RwLock<Option<Zeroizing<String>>> = RwLock::new(None);
 
+/// Serializes tests that read or mutate the process-global master key
+/// (`ENCRYPTION_KEY` / `RAW_MASTER_KEY`). The crypto module tests and the
+/// cloud-sync tests that derive team keys from the master key must all hold this
+/// lock, otherwise a concurrent `set_master_key` from one test can make another
+/// test's refresh/sync path observe an unexpected master-key state.
+#[cfg(test)]
+pub(crate) fn crypto_test_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
 /// 获取数据目录路径
 fn get_data_dir() -> Option<PathBuf> {
     crate::app_dirs::data_dir()
@@ -726,7 +737,7 @@ pub fn try_restore_master_key() -> bool {
 mod tests {
     use super::*;
     use crate::key_storage::KeyStorage;
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::Mutex;
 
     #[derive(Default)]
     struct MemoryKeyStorage {
@@ -819,13 +830,18 @@ mod tests {
     }
 
     fn test_mutex() -> &'static Mutex<()> {
-        static MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
-        MUTEX.get_or_init(|| Mutex::new(()))
+        super::crypto_test_lock()
+    }
+
+    fn crypto_guard() -> std::sync::MutexGuard<'static, ()> {
+        // Tolerate poisoning: a panic in any test while holding the shared
+        // master-key lock must not cascade-fail every other lock acquisition.
+        test_mutex().lock().unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     #[test]
     fn test_encrypt_decrypt() {
-        let _guard = test_mutex().lock().unwrap();
+        let _guard = crypto_guard();
         set_master_key("test_key_123").expect("configure test master key");
 
         let original = "my_secret_password";
@@ -842,7 +858,7 @@ mod tests {
 
     #[test]
     fn test_key_verification() {
-        let _guard = test_mutex().lock().unwrap();
+        let _guard = crypto_guard();
         let master_key = "test_key_123";
         let verification = generate_key_verification(master_key);
 
@@ -852,7 +868,7 @@ mod tests {
 
     #[test]
     fn test_empty_password() {
-        let _guard = test_mutex().lock().unwrap();
+        let _guard = crypto_guard();
         set_master_key("test_key").expect("configure test master key");
 
         let encrypted = encrypt_password("");
@@ -866,7 +882,7 @@ mod tests {
 
     #[test]
     fn test_no_master_key() {
-        let _guard = test_mutex().lock().unwrap();
+        let _guard = crypto_guard();
         clear_master_key();
 
         let original = "password123";
@@ -881,7 +897,7 @@ mod tests {
 
     #[test]
     fn test_already_encrypted() {
-        let _guard = test_mutex().lock().unwrap();
+        let _guard = crypto_guard();
         set_master_key("test_key").expect("configure test master key");
 
         let original = "password";
@@ -959,7 +975,7 @@ mod tests {
 
     #[test]
     fn first_setup_does_not_publish_when_verification_save_fails() {
-        let _guard = test_mutex().lock().unwrap();
+        let _guard = crypto_guard();
         let storage = MemoryKeyStorage::default();
         clear_in_memory_master_key();
 
@@ -980,7 +996,7 @@ mod tests {
 
     #[test]
     fn unlock_does_not_publish_after_partial_storage_failure() {
-        let _guard = test_mutex().lock().unwrap();
+        let _guard = crypto_guard();
         let storage = FailOnceKeyStorage::fail_save("old-key");
         clear_in_memory_master_key();
 
@@ -1001,7 +1017,7 @@ mod tests {
 
     #[test]
     fn session_only_unlock_does_not_publish_after_partial_delete_failure() {
-        let _guard = test_mutex().lock().unwrap();
+        let _guard = crypto_guard();
         let storage = FailOnceKeyStorage::fail_delete("old-key");
         clear_in_memory_master_key();
 
@@ -1022,7 +1038,7 @@ mod tests {
 
     #[test]
     fn successful_setup_publishes_after_persistence() {
-        let _guard = test_mutex().lock().unwrap();
+        let _guard = crypto_guard();
         let storage = MemoryKeyStorage::default();
         clear_in_memory_master_key();
 

--- a/crates/core/src/storage/credential_vault/tests/mod.rs
+++ b/crates/core/src/storage/credential_vault/tests/mod.rs
@@ -7,7 +7,7 @@ mod repository_tests;
 mod resolver_tests;
 mod runtime_resolver_tests;
 
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::MutexGuard;
 
 use tempfile::TempDir;
 
@@ -18,8 +18,7 @@ use crate::storage::migration::run_migrations;
 use super::super::CredentialRepository;
 
 pub(super) fn crypto_guard() -> MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
+    crate::crypto::crypto_test_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }

--- a/crates/core/src/storage/models.rs
+++ b/crates/core/src/storage/models.rs
@@ -2504,6 +2504,9 @@ mod tests {
 
     #[test]
     fn extension_connection_encrypts_arbitrary_secret_fields() {
+        let _crypto_guard = crate::crypto::crypto_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         crypto::set_master_key_for_session("extension-connection-test-key").unwrap();
         let params = ExtensionConnectionParams::new(
             "com.example.search",

--- a/crates/core/src/storage/repository.rs
+++ b/crates/core/src/storage/repository.rs
@@ -950,6 +950,9 @@ mod tests {
 
     #[test]
     fn extension_connections_use_standard_repository_and_scoped_secrets() {
+        let _crypto_guard = crate::crypto::crypto_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         crate::crypto::set_master_key_for_session("extension-connection-test-key").unwrap();
         let (conn, repo) = test_repository();
         let params = ExtensionConnectionParams::new(

--- a/crates/core/src/tab_container_drag_contract_tests.rs
+++ b/crates/core/src/tab_container_drag_contract_tests.rs
@@ -20,7 +20,7 @@ fn macos_keeps_tab_drag_enabled_while_blank_space_moves_the_window() {
     assert!(!tabs_block.contains("window_control_area(WindowControlArea::Drag)"));
     assert!(!tabs_block.contains(".child(right_window_drag_region)"));
     assert!(tabs_scroll < tabs_boundary);
-    assert!(source[tabs_boundary..].contains(".child(right_window_drag_region)"));
+    assert!(source[tabs_boundary..].contains(".child(right_window_drag_region"));
     assert!(source.contains(".on_drag("));
     assert!(source.contains("DragTab::new("));
 }

--- a/crates/core/src/tab_container_layout_contract_tests.rs
+++ b/crates/core/src/tab_container_layout_contract_tests.rs
@@ -171,7 +171,7 @@ fn sidebar_center_clips_active_view_intrinsic_size_at_every_flex_boundary() {
         .find("let center = if bottom.is_empty()")
         .expect("sidebar center layout");
     let center_end = renderer[center_start..]
-        .find("let mut root = div()")
+        .find("let mut root = gpui_component::ElementExt::on_prepaint(")
         .map(|offset| center_start + offset)
         .expect("sidebar root layout");
     let center = &renderer[center_start..center_end];
@@ -307,7 +307,7 @@ fn sidebar_resize_uses_tab_container_bounds_instead_of_window_bounds() {
     let renderer = &source[renderer_start..renderer_end];
 
     assert!(renderer.contains(".id(\"tab-sidebar-root\")"));
-    assert!(renderer.contains(".on_prepaint({"));
+    assert!(renderer.contains("ElementExt::on_prepaint("));
     assert!(renderer.contains("container.sidebar_bounds = bounds;"));
 
     let handler_start = source

--- a/crates/extension-plugin-adapter/src/tests.rs
+++ b/crates/extension-plugin-adapter/src/tests.rs
@@ -1445,6 +1445,7 @@ fn binding_rejects_missing_spawn_permission() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn allowlisted_absolute_program_still_constrains_extension_working_directory() {
     let extension = tempfile::TempDir::new().unwrap();

--- a/crates/extension-runtime/src/connection_import_provider_tests.rs
+++ b/crates/extension-runtime/src/connection_import_provider_tests.rs
@@ -15,6 +15,36 @@ use fixtures::{
     write_broken_wasm_importer_extension, write_wasm_importer_extension,
 };
 
+/// The platform the test harness runs on. `ManifestConnectionImportHost` only
+/// exposes candidates whose `platform` matches the host's current platform, so
+/// tests that exercise visible candidates must label them with the runner's own
+/// platform instead of hard-coding `Platform::Macos` (which silently hides them
+/// on Linux/Windows CI and turns a permission check into `UndeclaredCandidate`).
+#[cfg(target_os = "windows")]
+fn runner_platform() -> Platform {
+    Platform::Windows
+}
+
+#[cfg(target_os = "linux")]
+fn runner_platform() -> Platform {
+    Platform::Linux
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+fn runner_platform() -> Platform {
+    Platform::Macos
+}
+
+/// A build target platform that is guaranteed to differ from the runner's own,
+/// so a candidate tagged with it is always hidden on the current host.
+fn other_platform() -> Platform {
+    match runner_platform() {
+        Platform::Windows => Platform::Linux,
+        Platform::Linux => Platform::Macos,
+        Platform::Macos => Platform::Windows,
+    }
+}
+
 #[test]
 fn connection_import_provider_lists_manifest_importers_with_scoped_ids() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -238,7 +268,7 @@ fn manifest_connection_import_host_requires_manifest_fs_read_permission() {
     let host = ManifestConnectionImportHost::new(
         vec![CandidateFile {
             id: "connections".to_string(),
-            platform: Some(Platform::Macos),
+            platform: Some(runner_platform()),
             path: candidate_path.to_string_lossy().to_string(),
         }],
         Vec::<String>::new(),
@@ -294,7 +324,7 @@ fn manifest_connection_import_host_rejects_reads_for_other_platform_candidates()
     let host = ManifestConnectionImportHost::new(
         vec![CandidateFile {
             id: "windows-only".to_string(),
-            platform: Some(Platform::Windows),
+            platform: Some(other_platform()),
             path: path.clone(),
         }],
         [format!("fs:read:{path}")],
@@ -333,7 +363,7 @@ fn manifest_connection_import_host_reads_nested_directory_entries() {
     let host = ManifestConnectionImportHost::new(
         vec![CandidateFile {
             id: "securecrt-config".to_string(),
-            platform: Some(Platform::Macos),
+            platform: Some(runner_platform()),
             path: config_path.clone(),
         }],
         [format!("fs:read:{config_path}")],
@@ -358,7 +388,7 @@ fn manifest_connection_import_host_rejects_nested_directory_parent_escape() {
     let host = ManifestConnectionImportHost::new(
         vec![CandidateFile {
             id: "securecrt-config".to_string(),
-            platform: Some(Platform::Macos),
+            platform: Some(runner_platform()),
             path: config_path.clone(),
         }],
         [format!("fs:read:{config_path}")],

--- a/crates/extension-runtime/src/extension_downloader_archive_tests.rs
+++ b/crates/extension-runtime/src/extension_downloader_archive_tests.rs
@@ -209,14 +209,6 @@ fn append_bytes(
     append_bytes_with_mode(archive, name, bytes, 0o644);
 }
 
-fn append_executable_bytes(
-    archive: &mut tar::Builder<flate2::write::GzEncoder<Vec<u8>>>,
-    name: &str,
-    bytes: &[u8],
-) {
-    append_bytes_with_mode(archive, name, bytes, 0o755);
-}
-
 fn append_bytes_with_mode(
     archive: &mut tar::Builder<flate2::write::GzEncoder<Vec<u8>>>,
     name: &str,

--- a/crates/extension-runtime/src/extension_runtime_contract_tests.rs
+++ b/crates/extension-runtime/src/extension_runtime_contract_tests.rs
@@ -799,7 +799,7 @@ fn catalog_toolbox_views_exclude_connection_owned_shell_views() {
     let mut owned = shell_view("ui/explorer.js");
     owned.id = "explorer".into();
 
-    let mut manifest = base_manifest();
+    let mut manifest = shell_manifest();
     manifest.contributes.shell_views.push(standalone_tab);
     manifest.contributes.shell_views.push(standalone_toolbox);
     manifest.contributes.shell_views.push(owned);

--- a/crates/extension-runtime/src/global.rs
+++ b/crates/extension-runtime/src/global.rs
@@ -230,7 +230,12 @@ mod tests {
     fn invalid_development_manifest_does_not_remove_valid_views() {
         let valid = development_manifest("dev.valid", "/tmp/valid", "tool");
         let mut invalid = development_manifest("dev.invalid", "/tmp/invalid", "tool");
-        invalid.contributes.shell_views[0].category = None;
+        // `shellView.category` is optional (only validated when present), so make
+        // the development manifest genuinely invalid instead: a toolbox view with
+        // an undeclared IPC runtime backend is rejected by `validate_backends`.
+        invalid.contributes.shell_views[0]
+            .backends
+            .insert("search".into(), "missing".into());
 
         let (catalog, accepted, report) =
             build_catalog_with_development(Vec::new(), &[valid, invalid]).unwrap();

--- a/crates/markdown-editor/src/editor/context_menu.rs
+++ b/crates/markdown-editor/src/editor/context_menu.rs
@@ -1360,7 +1360,7 @@ mod tests {
             (table_block, cell)
         });
 
-        cx.update(|window, _cx| window.blur());
+        cx.update(|window, cx| window.blur(cx));
         cx.update(|window, cx| {
             editor.update(cx, |editor, cx| {
                 editor.apply_table_menu_action(

--- a/crates/markdown-editor/src/editor/enlarged.rs
+++ b/crates/markdown-editor/src/editor/enlarged.rs
@@ -490,7 +490,7 @@ mod tests {
                 .entity
                 .clone()
         });
-        cx.update(|window, _| window.blur());
+        cx.update(|window, cx| window.blur(cx));
         redraw(cx);
 
         let source_button = cx
@@ -533,7 +533,7 @@ mod tests {
                 .entity
                 .clone()
         });
-        cx.update(|window, _| window.blur());
+        cx.update(|window, cx| window.blur(cx));
         redraw(cx);
 
         math_block.update(cx, |block, cx| {

--- a/crates/markdown-editor/src/editor/window_state.rs
+++ b/crates/markdown-editor/src/editor/window_state.rs
@@ -678,7 +678,7 @@ mod tests {
             (table_block, second_cell, table_id)
         });
 
-        cx.update(|window, _| window.blur());
+        cx.update(|window, cx| window.blur(cx));
         redraw(cx);
         let baseline = cx.debug_bounds("table-root").expect("table root lays out");
         assert!(
@@ -761,7 +761,7 @@ mod tests {
             );
         });
 
-        cx.update(|window, _| window.blur());
+        cx.update(|window, cx| window.blur(cx));
         redraw(cx);
         assert!(
             cx.debug_bounds("table-toolbar").is_none(),

--- a/crates/notes/src/notes_view.rs
+++ b/crates/notes/src/notes_view.rs
@@ -377,6 +377,9 @@ mod external_markdown_tests {
         let tab_content = cx.debug_bounds("tab-content").expect("tab content");
         let markdown_editor = cx.debug_bounds("markdown-editor").expect("markdown editor");
         let dropdown = cx.debug_bounds("tab-dropdown-btn").expect("tab dropdown");
+        let background_task = cx
+            .debug_bounds("background-task-entry")
+            .expect("background task entry");
 
         assert_eq!(
             main_slot.right(),
@@ -384,9 +387,14 @@ mod external_markdown_tests {
             "main={main_slot:?}, container={tab_container:?}, bar={tab_bar:?}, content={tab_content:?}, editor={markdown_editor:?}"
         );
         assert_eq!(
-            tab_bar.right(),
             dropdown.right(),
-            "Markdown content must not determine the tab switcher's horizontal position"
+            background_task.left(),
+            "Markdown content must not move the tab switcher away from the trailing tab-bar chrome"
+        );
+        assert_eq!(
+            tab_bar.right(),
+            background_task.right(),
+            "the trailing tab-bar chrome must keep consuming the right edge regardless of content"
         );
     }
 

--- a/crates/notes/src/storage_tests.rs
+++ b/crates/notes/src/storage_tests.rs
@@ -209,7 +209,10 @@ fn legacy_location_config_without_flag_keeps_files_layout() -> Result<()> {
     let custom = temp.path().join("custom-notes");
     std::fs::create_dir_all(config.parent().unwrap())?;
     std::fs::create_dir_all(&custom)?;
-    std::fs::write(&config, format!(r#"{{"root":"{}"}}"#, custom.display()))?;
+    // Windows paths use backslashes, which must be escaped inside JSON strings;
+    // otherwise `configured_location_from` fails to parse the legacy config.
+    let escaped_root = custom.display().to_string().replace('\\', "\\\\");
+    std::fs::write(&config, format!(r#"{{"root":"{escaped_root}"}}"#))?;
 
     let (root, use_files_subdir) = NotesStorage::configured_location_from(&config, &default)?;
     assert_eq!(custom, root);

--- a/crates/terminal_view/src/view/tests/layout.rs
+++ b/crates/terminal_view/src/view/tests/layout.rs
@@ -706,10 +706,22 @@ fn terminal_command_bar_keeps_oxideterm_keyboard_and_overlay_contracts() {
     for key in ["\"tab\"", "\"escape\""] {
         assert!(interaction_source.contains(key));
     }
-    assert!(
-        render_source.contains(".vertical_navigation(false)"),
-        "command input must delegate Up/Down instead of consuming them as cursor movement"
-    );
+    // The externalized gpui-component Input no longer exposes `vertical_navigation`;
+    // Up/Down are delegated to history navigation through MoveUp/MoveDown actions
+    // bound on the bar below. handle_key_down must therefore never consume the
+    // arrow keys as cursor movement.
+    let key_down_body = interaction_source
+        .split("fn handle_key_down")
+        .nth(1)
+        .and_then(|source| source.split("fn input_has_focus").next())
+        .expect("handle_key_down body");
+    for key in ["\"arrowup\"", "\"arrowdown\""] {
+        assert!(
+            !key_down_body.contains(key),
+            "command input must delegate Up/Down to history navigation instead of consuming them \
+             as cursor movement"
+        );
+    }
     assert!(render_source.contains(".on_action(cx.listener(Self::handle_history_previous))"));
     assert!(render_source.contains(".on_action(cx.listener(Self::handle_history_next))"));
     assert!(interaction_source.contains("fn handle_history_previous"));
@@ -729,7 +741,6 @@ fn terminal_command_bar_keeps_oxideterm_keyboard_and_overlay_contracts() {
         .expect("refresh suggestions implementation should exist");
     assert!(refresh.contains("build_command_suggestions"));
     assert!(refresh.contains("command_inline_suffix"));
-    assert!(refresh.contains("set_inline_completion_text"));
     assert!(!refresh.contains("reset_overlays"));
     assert!(render_source.contains("toggle_collapsed"));
     assert!(interaction_source.contains("TerminalCommandBarEvent::FocusTerminal"));
@@ -755,7 +766,7 @@ fn terminal_command_bar_keeps_oxideterm_keyboard_and_overlay_contracts() {
         "hover must not change the command-bar grip height or cause a geometry jump"
     );
     assert!(render_source.contains("cx.theme().drag_border"));
-    assert!(render_source.contains("Input::new(&self.input_state)"));
+    assert!(render_source.contains("Textarea::new(&self.input_state)"));
     assert!(!render_source.contains(".h_full()"));
     assert!(render_source.contains(".h(px(self.input_height))"));
     assert!(render_source.contains("drag.initial_height + delta"));
@@ -764,7 +775,10 @@ fn terminal_command_bar_keeps_oxideterm_keyboard_and_overlay_contracts() {
     assert!(render_source.contains("initial_y - event.event.position.y"));
     assert!(!render_source.contains("event.bounds.center().y"));
     assert!(render_source.contains("if drag.entity_id != cx.entity_id()"));
-    assert!(render_source.contains("with_size(Size::Medium)"));
+    assert!(
+        include_str!("../command_bar/quick_render_list.rs").contains("with_size(Size::Medium)"),
+        "the quick-command empty state icon must stay Medium-sized"
+    );
     let expanded_row = render_source
         .split("fn render_input_row")
         .nth(1)
@@ -780,7 +794,7 @@ fn terminal_command_bar_keeps_oxideterm_keyboard_and_overlay_contracts() {
     assert!(terminal_toggle.contains("IconName::ChevronUp"));
     assert!(terminal_toggle.contains("IconName::ChevronDown"));
     assert!(!terminal_toggle.contains("self.target_label(cx)"));
-    assert!(terminal_toggle.contains("when(!self.collapsed"));
+    assert!(terminal_toggle.contains(".selected(!self.collapsed)"));
     assert!(render_source.contains("this.toggle_collapsed(window, cx)"));
     assert!(expanded_row.contains("self.render_expanded_actions(cx)"));
     assert!(expanded_row.contains("self.render_terminal_toggle_button(cx)"));
@@ -797,7 +811,7 @@ fn terminal_command_bar_keeps_oxideterm_keyboard_and_overlay_contracts() {
         .find("self.render_terminal_toggle_button(cx)")
         .expect("terminal toggle should render in the expanded row");
     let input_position = expanded_row
-        .find("Input::new(&self.input_state)")
+        .find("Textarea::new(&self.input_state)")
         .expect("command input should render in the expanded row");
     let actions_position = expanded_row
         .find("self.render_expanded_actions(cx)")

--- a/script/test-release-packaging.mjs
+++ b/script/test-release-packaging.mjs
@@ -224,6 +224,7 @@ test("portable Linux disables WebView while standard builds keep it", () => {
   const workspaceCargo = read("Cargo.toml");
   const cargo = read("crates/ai_chat_view/Cargo.toml");
   const mainCargo = read("main/Cargo.toml");
+  const universalPluginsCargo = read("crates/universal-plugins/Cargo.toml");
   const htmlCodeBlock = read(
     "crates/ai_chat_view/src/html_code_block.rs",
   );
@@ -263,14 +264,18 @@ test("portable Linux disables WebView while standard builds keep it", () => {
   );
   assert.match(
     mainCargo,
-    /gpui-shell = \{ workspace = true, optional = true \}/,
+    /shell-plugins = \["universal-plugins\/shell-plugins"\]/,
   );
   assert.match(
-    mainCargo,
-    /gpui-component-shell = \{ workspace = true, optional = true \}/,
+    universalPluginsCargo,
+    /gpui-shell = \{[^}]*optional = true[^}]*\}/,
   );
   assert.match(
-    mainCargo,
+    universalPluginsCargo,
+    /gpui-component-shell = \{[^}]*optional = true[^}]*\}/,
+  );
+  assert.match(
+    universalPluginsCargo,
     /shell-plugins = \["dep:gpui-shell", "dep:gpui-component-shell"\]/,
   );
   assert.match(

--- a/tools/windows-rdp-probe/tests/contract.rs
+++ b/tools/windows-rdp-probe/tests/contract.rs
@@ -351,7 +351,7 @@ fn windows_setup_requires_native_desktop_atl_and_system_typelib() {
             X64_TARGET,
             X86_TARGET,
             PROBE_BUILD,
-            "$vs2022VersionRange = \"[17.0,18.0)\"",
+            "$supportedVisualStudioVersionRange = \"[17.0,19.0)\"",
             "chcp 65001 >nul",
             "Compile-only probe gate",
         ],


### PR DESCRIPTION
修复 CI 各平台 cargo test --all 的 8 层确定性失败 + cloud_sync 并行 flake，本地并行全量 203 目标已全绿。

详见 commit 71fe344c4。