### PR TITLE
feat(settings): add interface scale setting for UI zoom (fix #146)

### DIFF
--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -853,6 +853,12 @@ pub struct AppSettings {
     pub font_family: String,
     #[serde(default = "default_font_size")]
     pub font_size: f64,
+    /// 界面缩放百分比（100 = 默认大小）。
+    ///
+    /// 该值会与 `font_size` 相乘作为 GPUI 的 rem 基准长度，从而整体缩放以 rem
+    /// 表达的界面尺寸，效果等同于浏览器缩放，便于在 4K 等高分辨率屏幕上使用。
+    #[serde(default = "default_ui_scale_percent")]
+    pub ui_scale_percent: u32,
     #[serde(default = "default_monospace_font_family")]
     pub sql_editor_font_family: String,
     #[serde(default = "default_sql_editor_font_size")]
@@ -1007,6 +1013,17 @@ fn default_custom_accent_color() -> String {
 
 fn default_font_size() -> f64 {
     14.0
+}
+
+/// 界面缩放允许的最小百分比。
+pub const UI_SCALE_PERCENT_MIN: u32 = 50;
+
+/// 界面缩放允许的最大百分比。
+pub const UI_SCALE_PERCENT_MAX: u32 = 300;
+
+/// 界面缩放的默认值（百分比）。
+fn default_ui_scale_percent() -> u32 {
+    100
 }
 
 fn default_sql_editor_font_size() -> f64 {
@@ -1243,6 +1260,7 @@ impl Default for AppSettings {
             custom_accent_color: default_custom_accent_color(),
             font_family: default_font_family(),
             font_size: default_font_size(),
+            ui_scale_percent: default_ui_scale_percent(),
             sql_editor_font_family: default_monospace_font_family(),
             sql_editor_font_size: default_sql_editor_font_size(),
             table_preview_font_family: default_monospace_font_family(),
@@ -1566,12 +1584,25 @@ impl AppSettings {
 
         let theme = Theme::global_mut(cx);
         theme.font_family = resolved.into();
-        theme.font_size = px(self.font_size as f32);
+        // GPUI 的 rem 基准长度取自主题字号（gpui-component 的 `Root::render` 会调用
+        // `window.set_rem_size(cx.theme().font_size)`），因此把界面缩放倍率乘进字号，
+        // 即可整体缩放所有以 rem 表达的字体、间距与控件尺寸。
+        theme.font_size = px(self.font_size as f32 * self.ui_scale());
         Theme::sync_base(cx);
     }
 
     pub fn apply_font_size(&self, cx: &mut App) {
         self.apply_font_settings(cx);
+    }
+
+    /// 界面缩放倍率（1.0 表示 100%）。
+    ///
+    /// 超出允许范围的值会被收敛到 [`UI_SCALE_PERCENT_MIN`] /
+    /// [`UI_SCALE_PERCENT_MAX`] 之间，避免产生不可用的界面尺寸。
+    pub fn ui_scale(&self) -> f32 {
+        self.ui_scale_percent
+            .clamp(UI_SCALE_PERCENT_MIN, UI_SCALE_PERCENT_MAX) as f32
+            / 100.0
     }
 
     /// 应用通用字体族设置到主题（设置面板修改"字体"后调用）。
@@ -1969,6 +2000,36 @@ mod tests {
     }
 
     #[test]
+    fn ui_scale_defaults_to_identity_and_clamps_out_of_range_values() {
+        let mut settings = AppSettings::default();
+        assert_eq!(100, settings.ui_scale_percent);
+        assert!((settings.ui_scale() - 1.0).abs() < f32::EPSILON);
+
+        settings.ui_scale_percent = 150;
+        assert!((settings.ui_scale() - 1.5).abs() < f32::EPSILON);
+
+        settings.ui_scale_percent = 10;
+        let min_scale = super::UI_SCALE_PERCENT_MIN as f32 / 100.0;
+        assert!((settings.ui_scale() - min_scale).abs() < f32::EPSILON);
+
+        settings.ui_scale_percent = 10_000;
+        let max_scale = super::UI_SCALE_PERCENT_MAX as f32 / 100.0;
+        assert!((settings.ui_scale() - max_scale).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn ui_scale_percent_is_read_from_persisted_settings() {
+        let settings: AppSettings =
+            serde_json::from_str(r#"{ "ui_scale_percent": 175 }"#).expect("ui_scale_percent 应能读取");
+        assert_eq!(175, settings.ui_scale_percent);
+        assert!((settings.ui_scale() - 1.75).abs() < f32::EPSILON);
+
+        // 旧配置文件缺少该字段时应回落到 100%。
+        let legacy: AppSettings = serde_json::from_str("{}").expect("旧配置应能读取");
+        assert_eq!(100, legacy.ui_scale_percent);
+    }
+
+    #[test]
     fn app_settings_does_not_require_master_key_on_startup_by_default() {
         assert!(!AppSettings::default().require_master_key_on_startup);
     }
@@ -2305,6 +2366,41 @@ mod tests {
             settings.apply(cx);
 
             assert_eq!(px(18.0), Theme::global(cx).font_size);
+        });
+    }
+
+    #[gpui::test]
+    fn app_settings_apply_scales_theme_font_size_by_ui_scale(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            gpui_component::init(cx);
+            cx.set_global(Theme::default());
+
+            let mut settings = AppSettings::default();
+            settings.font_size = 14.0;
+            settings.ui_scale_percent = 150;
+
+            settings.apply(cx);
+
+            // 界面缩放会与字号相乘后写入主题字号，而 gpui-component 的 Root 会用它
+            // 作为窗口 rem 基准长度，从而整体缩放界面。
+            assert_eq!(px(21.0), Theme::global(cx).font_size);
+        });
+    }
+
+    #[gpui::test]
+    fn app_settings_apply_keeps_theme_font_size_at_identity_for_default_ui_scale(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            gpui_component::init(cx);
+            cx.set_global(Theme::default());
+
+            let settings = AppSettings::default();
+
+            settings.apply(cx);
+
+            // 默认缩放为 100% 时行为与改动前一致。
+            assert_eq!(px(14.0), Theme::global(cx).font_size);
         });
     }
 

--- a/main/locales/main.yml
+++ b/main/locales/main.yml
@@ -2530,6 +2530,14 @@ Settings:
         en: Adjust font size for better readability (8-72)
         zh-CN: 调整字体大小以获得更好的可读性（8-72）
         zh-HK: 調整字型大小以獲得更好的可讀性（8-72）
+      ui_scale:
+        en: Interface Scale
+        zh-CN: 界面缩放
+        zh-HK: 介面縮放
+      ui_scale_desc:
+        en: Scale the whole interface (fonts, spacing and controls); useful on high-resolution displays
+        zh-CN: 整体缩放界面（字体、间距与控件），适合 4K 等高分辨率屏幕
+        zh-HK: 整體縮放介面（字型、間距與控件），適合 4K 等高解析度螢幕
 
     LocalTerminal:
       group_title:

--- a/main/src/setting_tab.rs
+++ b/main/src/setting_tab.rs
@@ -773,6 +773,39 @@ impl SettingsPanel {
                                 .default_value(default_settings.font_size),
                             )
                             .description(t!("Settings.General.Font.font_size_desc").to_string()),
+                        )
+                        .item(
+                            SettingItem::new(
+                                t!("Settings.General.Font.ui_scale"),
+                                SettingField::dropdown(
+                                    vec![
+                                        ("100".into(), "100%".into()),
+                                        ("110".into(), "110%".into()),
+                                        ("125".into(), "125%".into()),
+                                        ("150".into(), "150%".into()),
+                                        ("175".into(), "175%".into()),
+                                        ("200".into(), "200%".into()),
+                                    ],
+                                    |cx: &App| {
+                                        SharedString::from(
+                                            AppSettings::global(cx).ui_scale_percent.to_string(),
+                                        )
+                                    },
+                                    |val: SharedString, cx: &mut App| {
+                                        let percent = val.trim().parse::<u32>().unwrap_or(100);
+                                        AppSettings::update_and_save(cx, |settings| {
+                                            settings.ui_scale_percent = percent;
+                                        });
+                                        // rem 基准长度取自主题字号，因此改缩放后需重新应用字体设置。
+                                        AppSettings::current(cx).apply_font_size(cx);
+                                        cx.refresh_windows();
+                                    },
+                                )
+                                .default_value(SharedString::from(
+                                    default_settings.ui_scale_percent.to_string(),
+                                )),
+                            )
+                            .description(t!("Settings.General.Font.ui_scale_desc").to_string()),
                         ),
                     SettingGroup::new()
                         .title(t!("Settings.General.Log.group_title"))


### PR DESCRIPTION
Fixes #146

## 问题

4K 等高分辨率屏幕下界面偏小，且没有任何缩放选项。

## 实现方式

发现 gpui-component 的 `Root::render` 每帧执行 `window.set_rem_size(cx.theme().font_size)`（crates/ui/src/root.rs），即主题字号就是全局 rem 基准。因此：

- 新增 `ui_scale_percent` 设置（50~300，默认 100，serde default 兼容旧配置，读取时收敛到合法区间）
- `apply_font_settings` 中 `theme.font_size = px(font_size × ui_scale)`，与现有「字体大小」设置正交叠加
- 设置页 通用 → 字体 新增「界面缩放」下拉（100/110/125/150/175/200%），修改后立即 `apply_font_size` + `refresh_windows` 生效
- i18n：en / zh-CN / zh-HK

## 测试

- `cargo check -p one-core` / `-p main` 通过
- one-core 全量单测 648 通过（含新增 4 个：2 个换算/兼容性单测 + 2 个 `#[gpui::test]` 端到端断言 `Theme::global(cx).font_size`，150% → 21px、100% → 14px 行为不变）
- 本地编译运行验证：设置中切换缩放立即生效

基准分支为最新 dev（7f813454f），cherry-pick 无冲突。