### PR TITLE
fix(redis): 键树搜索不再二次过滤服务端结果，并改为输入停顿后自动扫描 (#181)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -603,6 +603,13 @@
 - **验证方式**：`cargo test -p redis_view`；纯函数测试覆盖 `search_filter_keyword` / `resolve_search_targets` / `local_search_visibility`，另有一个用 `set_node_children` 搭真实节点树的 gpui 测试（服务端命中跨命名空间键时可见 + 无服务端扫描记录时被隐藏的对照分支，防空跑），并跑一遍 `render` 覆盖新提示分支。改动做变异验证：分别去掉「免二次过滤」「结构锚点保留」「搜索态展开」，测试都转红。
 - **适用范围**：`crates/redis_view/src/redis_tree_view.rs`，以及任何「先本地过滤已加载子集、再服务端扫描」的懒加载树（其他 tree_view 同类结构）。
 
+- **标题**：GPUI 输入防抖：替换 `Option<Task>` 就等于取消定时器，别凭空加代次守卫；但 `emit` 是延迟 effect
+- **触发信号**：要给输入框 / 编辑器做「停止输入一小段时间后再发请求」的防抖；或者视图自己依赖「事件订阅方回写的状态」做去重时出现重复请求；也适用于怀疑「drop 掉 `Task` 是否真的取消定时器」而准备额外加 generation 代次守卫时。
+- **根因 / 约束**：本仓 gpui fork 里，`Task` 被 drop 后其 `cx.background_executor().timer(..)` 未到期部分**不会**再执行（已用对照测试验证：不 drop 时必然执行，drop 后不执行）。所以防抖只需「`Option<Task<()>>` 存字段 + 每次输入覆盖」，额外加的 generation 代次守卫是**死代码**（变异验证删掉它测试并不转红）。另一侧的坑更隐蔽：`Context::emit` 只是往 `pending_effects` 里塞一条 `Effect::Emit`，订阅者（如 `handle_search_keys` → `search_keys`）要等 flush 才跑，于是**订阅方回写的状态标记会滞后于 emit**；视图在 emit 之后立刻读这个标记做去重，会读到旧值。测试驱动输入用 `cx.simulate_input("we")` + `cx.executor().advance_clock(DEBOUNCE)` + `cx.run_until_parked()`；先 `cx.update(|window, cx| window.focus(&handle, cx))`，handle 用 `search_state.read(cx).focus_handle(cx)` 取（`Focusable` 的同名方法带 `cx` 参数会遮蔽零参版本）；断言事件用 `cx.subscribe(&entity, |entity, event, cx| ..)`，回调里可 `entity.update(cx, ..)`（emit 已 deferred，不会重入）。
+- **正确做法**：防抖状态机 = `Option<Task<()>>` + 纯函数判定 `should_scan_after_input(keyword, server_search_keyword)`（空关键词或已扫过 → 不发）；「立刻搜」入口（回车 / 搜索按钮）先 `self.search_debounce = None`，并在**同一函数内同步**写入「已交给服务端」的标记，不要指望事件兜一圈回来由订阅方补写；每次输入都替换 `Task` 字段即完成取消。
+- **验证方式**：`cargo test -p redis_view`；端到端用 `simulate_input` + `advance_clock` 断言「停顿前 0 次、停顿后 1 次、回车后不再补发」，并单独加一个对照分支测试证明 `drop(Task)` 会取消定时器——这样「多写一个代次守卫」这类死代码才会在变异验证里暴露。
+- **适用范围**：`crates/redis_view/src/redis_tree_view.rs`，以及任何 GPUI 视图中的输入防抖、定时器 + 事件订阅组合。
+
 ### 执行原则
 
 1. 先澄清，再实现；先缩小边界，再扩展范围。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -596,6 +596,13 @@
 - **验证方式**：`cargo check -p resource_view`、`cargo check -p main --features main/shell-plugins`；启动 app 肉眼核对浅/深色主题下的表头、斑马纹、hover、状态徽标、按钮 loading 与空/加载态。
 - **适用范围**：`crates/resource_view/src/{lib.rs,collection_table.rs}`、`navop-extensions/extensions/composite/*/extension.json` 的列 `style` 定义，以及任何用 Rust 原生渲染资源工作台/管理页面的场景。
 
+- **标题**：懒加载树的搜索：本地过滤不能叠在服务端结果上，过滤态必须保留结构锚点
+- **触发信号**：用户报「redis 搜不到 key」「搜索结果为空」，但服务端确实存在匹配的键；搜索时左侧树面板整个变空，连连接 / 数据库节点都消失。
+- **根因 / 约束**：`crates/redis_view/src/redis_tree_view.rs` 的搜索是两层——输入时按**单个树节点名**做本地子串过滤，回车 / 搜索按钮才走服务端 SCAN。三个坑：① 本地匹配的粒度是节点名、服务端匹配的是**整键**，所以 `*we*` 命中 `flow:east:1`（`we` 跨过 `:`）这类键会被服务端返回、又被本地二次过滤藏掉；② 过滤态下 `local_search_visibility` 会把「自身与子树都不匹配」的节点全剔除，连接 / 数据库一起消失，用户看到全空面板；而键列表是按需加载且上限 `SCAN_TARGET_KEYS = 500`，「本地没命中」是常态而非异常；③ 「搜索态自动展开」（issue #9）原来挂在「本地过滤生效」上，一旦关掉本地过滤，搜索结果会折叠成不可见。
+- **正确做法**：把两个状态拆开——`server_search_keyword`（最近一次交给服务端 SCAN 的关键词）与 `search_keyword`；两者相等时列表即服务端权威结果，`local_filter_keyword()` 直接返回 `None` 不做二次过滤。「自动展开」改用 `is_search_active()`（关键词非空），与「是否本地过滤」解耦。过滤态把 Connection / Database 当结构锚点无条件保留（`LocalSearchInput.is_structural`），并在「关键词非空但没有任何可见键」时区分提示「本地没匹配 → 引导回车扫描服务端」与「服务端也没匹配」。入口收敛到 `trigger_search`（回车与按钮共用，避免漂移），目标库用 `resolve_search_targets`（选中库优先，否则回退所有已连接库），避免未选中节点时回车静默无反应。
+- **验证方式**：`cargo test -p redis_view`；纯函数测试覆盖 `search_filter_keyword` / `resolve_search_targets` / `local_search_visibility`，另有一个用 `set_node_children` 搭真实节点树的 gpui 测试（服务端命中跨命名空间键时可见 + 无服务端扫描记录时被隐藏的对照分支，防空跑），并跑一遍 `render` 覆盖新提示分支。改动做变异验证：分别去掉「免二次过滤」「结构锚点保留」「搜索态展开」，测试都转红。
+- **适用范围**：`crates/redis_view/src/redis_tree_view.rs`，以及任何「先本地过滤已加载子集、再服务端扫描」的懒加载树（其他 tree_view 同类结构）。
+
 ### 执行原则
 
 1. 先澄清，再实现；先缩小边界，再扩展范围。

--- a/crates/redis_view/locales/redis_view.yml
+++ b/crates/redis_view/locales/redis_view.yml
@@ -605,6 +605,14 @@ RedisTree:
     en: "Type to filter current list. Press Enter or click search to scan server.\n*: matches zero or more characters, e.g. \"key*\".\n?: matches a single character, e.g. \"key?\".\n[]: matches a single character in range, e.g. \"key[1-3]\".\nEscape *, ?, [, ] with \\\\."
     zh-CN: "直接输入筛选当前列表，回车或点击搜索可对服务器进行扫描。\n*: 匹配零个或多个字符，例如\"key*\"匹配以\"key\"开头的所有键。\n?: 匹配单个字符，例如\"key?\"匹配\"key1\"、\"key2\"。\n[]: 匹配指定范围内的单个字符，例如\"key[1-3]\"可匹配\"key1\"、\"key2\"、\"key3\"。\n转义字符：要匹配 *、?、[、]，需要使用反斜杠\"\\\\\"进行转义。"
     zh-HK: "直接輸入篩選當前列表，回車或點擊搜尋可對伺服器進行掃描。\n*: 匹配零個或多個字符，例如\"key*\"匹配以\"key\"開頭的所有鍵。\n?: 匹配單個字符，例如\"key?\"匹配\"key1\"、\"key2\"。\n[]: 匹配指定範圍內的單個字符，例如\"key[1-3]\"可匹配\"key1\"、\"key2\"、\"key3\"。\n轉義字符：要匹配 *、?、[、]，需要使用反斜杠\"\\\\\"進行轉義。"
+  search_no_local_match:
+    en: "No key loaded so far matches \"%{keyword}\". Press Enter or click search to scan the server."
+    zh-CN: "已加载的键里没有匹配「%{keyword}」的，回车或点击搜索可扫描服务端。"
+    zh-HK: "已載入的鍵裡沒有匹配「%{keyword}」的，按回車或點擊搜尋可掃描伺服器。"
+  search_no_server_match:
+    en: "No key on the server matches \"%{keyword}\"."
+    zh-CN: "服务端没有匹配「%{keyword}」的键。"
+    zh-HK: "伺服器沒有匹配「%{keyword}」的鍵。"
   load_more:
     en: "Load more"
     zh-CN: "加载更多"

--- a/crates/redis_view/src/redis_tree_view.rs
+++ b/crates/redis_view/src/redis_tree_view.rs
@@ -1,12 +1,13 @@
 //! Redis 树形视图
 
 use std::collections::{HashMap, HashSet};
+use std::time::Duration;
 
 use connection_form::credential::resolve_connection_for_runtime;
 use gpui::{
     AnyElement, App, AppContext, AsyncApp, ClipboardItem, Context, Entity, EventEmitter,
     FocusHandle, Focusable, InteractiveElement, IntoElement, MouseButton, ParentElement, Render,
-    SharedString, StatefulInteractiveElement, Styled, UniformListScrollHandle, Window, div,
+    SharedString, StatefulInteractiveElement, Styled, Task, UniformListScrollHandle, Window, div,
     prelude::FluentBuilder, px, uniform_list,
 };
 use gpui_component::{ActiveTheme, Disableable, Icon, Side, Sizable, Size, button::{Button, ButtonVariants as _}, clipboard::Clipboard, h_flex, input::{Input, InputEvent, InputState}, menu::{ContextMenuExt, DropdownMenu, PopupMenu, PopupMenuItem}, popover::Popover, scroll::ScrollableElement, spinner::Spinner, v_flex};
@@ -26,6 +27,12 @@ const SCAN_BATCH_SIZE: usize = 500;
 const SCAN_TARGET_KEYS: usize = 500;
 const KEY_TYPES_BATCH_SIZE: usize = 200;
 const DEFAULT_REDIS_DATABASE_COUNT: usize = 16;
+
+/// 输入停顿多久后自动向服务端发起一次 SCAN。
+///
+/// 输入瞬间先用本地已加载的键给出即时反馈，停顿后才交给服务端覆盖结果：
+/// 用户既不必按回车，也不会每敲一个键就发一次请求。
+const SEARCH_INPUT_DEBOUNCE: Duration = Duration::from_millis(300);
 
 /// 树形视图事件
 #[derive(Clone, Debug)]
@@ -185,6 +192,17 @@ fn resolve_search_targets(
     targets
 }
 
+/// 判断一次输入停顿后是否需要向服务端发起 SCAN。
+///
+/// 返回 `false` 的两种情况：
+/// 1. 关键词为空——本地的完整列表就是正确结果，不该再发 SCAN；
+/// 2. 这个关键词已经（或正在）由服务端扫描——重复发起只是浪费一次往返。
+///    用户来回增删字符时会反复落到这个分支，所以这个判断同时充当了去重。
+fn should_scan_after_input(keyword: &str, server_search_keyword: Option<&str>) -> bool {
+    let keyword = keyword.trim();
+    !keyword.is_empty() && server_search_keyword != Some(keyword)
+}
+
 fn apply_redis_selection_state(
     selected_node: &mut Option<String>,
     context_menu_node_id: &mut Option<String>,
@@ -239,6 +257,12 @@ pub struct RedisTreeView {
     server_search_keyword: Option<String>,
     /// 搜索请求序号（node_id -> token）
     search_tokens: HashMap<String, u64>,
+    /// 待触发的「输入停顿后自动搜索」定时任务
+    ///
+    /// 每次输入都会替换它：被替换掉的 `Task` 一旦 drop，其未到期的定时器就不会
+    /// 再执行（见 `dropping_the_debounce_task_cancels_its_pending_timer`），
+    /// 于是只有最后一次输入能提交搜索，这就是防抖。
+    search_debounce: Option<Task<()>>,
     /// 数据库总键数（db_node_id -> total）
     db_total_key_counts: HashMap<String, i64>,
     /// 当前每个连接显示的数据库（connection_id -> db_index）
@@ -277,6 +301,8 @@ impl RedisTreeView {
                 this.search_collapsed_nodes.clear();
                 this.rebuild_flat_entries();
                 this.update_local_search_counts();
+                // 敲字停顿后自动扫服务端，用户不必再按回车。
+                this.schedule_search_after_input(cx);
                 cx.notify();
             }
 
@@ -297,6 +323,7 @@ impl RedisTreeView {
             search_keyword: String::new(),
             server_search_keyword: None,
             search_tokens: HashMap::new(),
+            search_debounce: None,
             db_total_key_counts: HashMap::new(),
             selected_databases: HashMap::new(),
             database_infos: HashMap::new(),
@@ -773,24 +800,26 @@ impl RedisTreeView {
     ///
     /// 回车与搜索按钮共用这一条路径，避免两个入口各自漂移。
     fn trigger_search(&mut self, cx: &mut Context<Self>) {
+        // 回车 / 点搜索按钮意味着「立刻搜」，撤掉还在等待的输入防抖，
+        // 否则防抖到期后会再扫一次同样的关键词。
+        self.search_debounce = None;
+
         self.search_keyword = self.search_state.read(cx).text().to_string();
         let pattern = self.search_keyword.trim().to_string();
-        let targets = self.search_target_node_ids();
 
         if pattern.is_empty() {
             // 清空关键词 = 回到「列出全部键」，同时解除服务端结果标记。
-            self.server_search_keyword = None;
-            self.search_collapsed_nodes.clear();
-            for node_id in targets {
-                self.reset_db_key_count(&node_id);
-                self.refresh_keys(node_id, cx);
-            }
-            self.rebuild_flat_entries();
-            cx.notify();
+            self.restore_full_key_list(cx);
             return;
         }
 
-        for node_id in targets {
+        // 同步标记为「已交给服务端」：事件是延迟 flush 的，若等订阅方
+        // （`handle_search_keys` → `search_keys`）来写这个标记，中间这段时间里
+        // 关键词看起来仍是「没扫过」的——回车后输入框补发的 Change 会因此
+        // 又武装一个防抖定时器，停顿后重复扫一次同样的关键词。
+        self.server_search_keyword = Some(pattern.clone());
+
+        for node_id in self.search_target_node_ids() {
             cx.emit(RedisTreeViewEvent::SearchKeys {
                 node_id,
                 pattern: pattern.clone(),
@@ -798,6 +827,46 @@ impl RedisTreeView {
         }
         self.rebuild_flat_entries();
         cx.notify();
+    }
+
+    /// 回到「列出全部键」：解除服务端结果标记并重新加载完整列表
+    ///
+    /// 服务端搜索会把键列表替换成命中结果，所以退出搜索必须重新 SCAN `*`，
+    /// 只把关键词置空是不够的。
+    fn restore_full_key_list(&mut self, cx: &mut Context<Self>) {
+        self.server_search_keyword = None;
+        self.search_collapsed_nodes.clear();
+        for node_id in self.search_target_node_ids() {
+            self.reset_db_key_count(&node_id);
+            self.refresh_keys(node_id, cx);
+        }
+        self.rebuild_flat_entries();
+        cx.notify();
+    }
+
+    /// 输入停顿后自动向服务端发起一次扫描（防抖）
+    ///
+    /// 输入瞬间先用本地已加载的键给出即时反馈，停顿后再交给服务端 SCAN 覆盖
+    /// 结果：用户既不必按回车，也不会每敲一个键就发一次请求。
+    fn schedule_search_after_input(&mut self, cx: &mut Context<Self>) {
+        // 新输入取代上一次的待触发定时器（旧的 Task 被 drop，其定时器随之取消）。
+        self.search_debounce = None;
+
+        if !should_scan_after_input(&self.search_keyword, self.server_search_keyword.as_deref()) {
+            // 关键词清空时，只有「上一轮是服务端结果」才需要重新加载完整列表。
+            if self.search_keyword.trim().is_empty() && self.server_search_keyword.is_some() {
+                self.restore_full_key_list(cx);
+            }
+            return;
+        }
+
+        self.search_debounce = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(SEARCH_INPUT_DEBOUNCE).await;
+            let _ = this.update(cx, |this, cx| {
+                this.search_debounce = None;
+                this.trigger_search(cx);
+            });
+        }));
     }
 
     /// 本次搜索应该扫描哪些数据库节点
@@ -2888,6 +2957,212 @@ mod tests {
     use super::*;
     use gpui::{AppContext, TestAppContext, VisualTestContext, WindowOptions};
     use gpui_component::Root;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    /// 在测试里搭建「一个已连接的连接 + 它的 db0」，返回 db 节点 id
+    fn mount_connected_db(tree: &mut RedisTreeView, cx: &mut Context<RedisTreeView>) -> String {
+        let db_node_id = RedisTreeView::db_node_id("conn", 0);
+        tree.connected_nodes.insert("conn".to_string());
+        tree.expanded_nodes.insert("conn".to_string());
+        tree.expanded_nodes.insert(db_node_id.clone());
+        tree.nodes.insert(
+            "conn".to_string(),
+            RedisNode::new("conn", "redis-master", RedisNodeType::Connection, "conn", 0),
+        );
+        tree.set_node_children(
+            "conn",
+            vec![RedisNode::new(
+                db_node_id.clone(),
+                "db0",
+                RedisNodeType::Database(0),
+                "conn",
+                0,
+            )],
+            cx,
+        );
+        db_node_id
+    }
+
+    #[gpui::test]
+    fn dropping_the_debounce_task_cancels_its_pending_timer(cx: &mut TestAppContext) {
+        // 对照分支：不被 drop 时，定时器必须会执行——否则下面的断言就是空跑。
+        let control_ran = Rc::new(RefCell::new(false));
+        let control_flag = control_ran.clone();
+        let control = cx.spawn(|cx| async move {
+            cx.background_executor().timer(SEARCH_INPUT_DEBOUNCE).await;
+            *control_flag.borrow_mut() = true;
+        });
+
+        cx.executor().advance_clock(SEARCH_INPUT_DEBOUNCE * 3);
+        cx.run_until_parked();
+        assert!(
+            *control_ran.borrow(),
+            "对照分支：未被 drop 的定时任务应当执行，否则本测试说明不了任何问题"
+        );
+        drop(control);
+
+        // 输入防抖靠「替换字段 = drop 掉上一次输入的 Task」来取消上一次输入，
+        // 所以这里必须确认 drop 真的会让未到期的定时器不再执行。
+        let ran = Rc::new(RefCell::new(false));
+        let flag = ran.clone();
+        let task = cx.spawn(|cx| async move {
+            cx.background_executor().timer(SEARCH_INPUT_DEBOUNCE).await;
+            *flag.borrow_mut() = true;
+        });
+        drop(task);
+
+        cx.executor().advance_clock(SEARCH_INPUT_DEBOUNCE * 3);
+        cx.run_until_parked();
+
+        assert!(
+            !*ran.borrow(),
+            "被 drop 的定时任务仍然执行了：输入防抖会漏出过期请求，必须改用显式代次守卫"
+        );
+    }
+
+    #[gpui::test]
+    fn clearing_the_search_box_cancels_the_pending_debounce(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            gpui_component::init(cx);
+            crate::init(cx);
+        });
+
+        let (window, tree) = cx.update(|cx| {
+            let mut tree = None;
+            let window = cx
+                .open_window(WindowOptions::default(), |window, cx| {
+                    let entity = cx.new(|cx| RedisTreeView::new(window, cx));
+                    tree = Some(entity.clone());
+                    cx.new(|cx| Root::new(entity, window, cx))
+                })
+                .expect("open redis tree test window");
+            (window, tree.expect("redis tree view"))
+        });
+
+        let mut cx = VisualTestContext::from_window(window.into(), cx);
+
+        tree.update_in(&mut cx, |tree, _window, cx| {
+            tree.search_keyword = "we".to_string();
+            tree.schedule_search_after_input(cx);
+            assert!(
+                tree.search_debounce.is_some(),
+                "输入新关键词后应有一个待触发的防抖定时器"
+            );
+
+            tree.search_keyword = String::new();
+            tree.schedule_search_after_input(cx);
+            assert!(
+                tree.search_debounce.is_none(),
+                "搜索框清空后，上一个关键词的防抖必须被撤掉，否则停顿后还会补一次刷新"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn typing_in_the_search_box_scans_the_server_after_a_pause(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            gpui_component::init(cx);
+            crate::init(cx);
+        });
+
+        let (window, tree) = cx.update(|cx| {
+            let mut tree = None;
+            let window = cx
+                .open_window(WindowOptions::default(), |window, cx| {
+                    let entity = cx.new(|cx| RedisTreeView::new(window, cx));
+                    tree = Some(entity.clone());
+                    cx.new(|cx| Root::new(entity, window, cx))
+                })
+                .expect("open redis tree test window");
+            (window, tree.expect("redis tree view"))
+        });
+
+        // 记录真正发往服务端的搜索请求。
+        //
+        // 真实链路里事件由 `handle_search_keys` 接住并调用 `search_keys`（后者会
+        // 发起一次真实 SCAN，并顺手把关键词标记为「已交给服务端」）。测试里只复刻
+        // 这个状态副作用，不碰网络。
+        let scanned: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+        let sink = scanned.clone();
+        cx.update(|cx| {
+            cx.subscribe(&tree, move |tree, event: &RedisTreeViewEvent, cx| {
+                let RedisTreeViewEvent::SearchKeys { pattern, .. } = event else {
+                    return;
+                };
+                sink.borrow_mut().push(pattern.clone());
+                let pattern = pattern.clone();
+                tree.update(cx, |tree, _| {
+                    tree.server_search_keyword = Some(pattern);
+                });
+            })
+            .detach();
+        });
+
+        let mut cx = VisualTestContext::from_window(window.into(), cx);
+        tree.update_in(&mut cx, |tree, _window, cx| {
+            mount_connected_db(tree, cx);
+        });
+        let focus_handle = tree.read_with(&cx, |tree, cx| {
+            tree.search_state.read(cx).focus_handle(cx).clone()
+        });
+
+        cx.update(|window, cx| window.focus(&focus_handle, cx));
+        cx.run_until_parked();
+
+        // 1) 敲字：只做本地过滤，不该马上打服务端
+        cx.simulate_input("we");
+        assert!(
+            scanned.borrow().is_empty(),
+            "输入后应等输入停顿，而不是每敲一个键就发一次 SCAN（实际 {:?}）",
+            scanned.borrow()
+        );
+        assert_eq!(
+            "we",
+            tree.read_with(&cx, |tree, _| tree.search_keyword.clone()),
+            "输入应立刻更新关键词，用于本地即时过滤"
+        );
+
+        // 2) 停顿到期：自动扫一次服务端
+        cx.executor().advance_clock(SEARCH_INPUT_DEBOUNCE);
+        cx.run_until_parked();
+        assert_eq!(
+            vec!["we".to_string()],
+            scanned.borrow().clone(),
+            "输入停顿后应自动向服务端发起一次搜索（这就是「不用按回车」的路径）"
+        );
+
+        // 3) 继续敲字后停顿：扫的是新关键词
+        cx.simulate_input("b");
+        assert_eq!(
+            1,
+            scanned.borrow().len(),
+            "新输入还没到停顿时间，不该发出请求"
+        );
+        cx.executor().advance_clock(SEARCH_INPUT_DEBOUNCE);
+        cx.run_until_parked();
+        assert_eq!(
+            vec!["we".to_string(), "web".to_string()],
+            scanned.borrow().clone()
+        );
+
+        // 4) 回车：立刻搜，并撤掉待触发的防抖（不能重复扫描同一关键词）
+        cx.simulate_input("3");
+        let before_enter = scanned.borrow().len();
+        cx.simulate_keystrokes("enter");
+        assert!(
+            scanned.borrow().len() > before_enter,
+            "回车应立即搜索，不等防抖"
+        );
+        let after_enter = scanned.borrow().len();
+        cx.executor().advance_clock(SEARCH_INPUT_DEBOUNCE);
+        cx.run_until_parked();
+        assert_eq!(
+            after_enter,
+            scanned.borrow().len(),
+            "回车已提交过，防抖到期不能再补一次同样的 SCAN"
+        );
+    }
 
     #[test]
     fn context_menu_target_updates_selection_and_clears_on_normal_selection() {
@@ -3110,6 +3385,42 @@ mod tests {
             None,
             search_filter_keyword("key*", None),
             "含通配符的关键词只能交给服务端 SCAN"
+        );
+    }
+
+    #[test]
+    fn input_debounce_skips_empty_and_already_scanned_keywords() {
+        assert!(
+            !should_scan_after_input("", None),
+            "清空搜索框应恢复完整列表，而不是拿空关键词去 SCAN"
+        );
+        assert!(
+            !should_scan_after_input("   ", Some("we")),
+            "只有空白的关键词等同于清空"
+        );
+        assert!(
+            !should_scan_after_input("we", Some("we")),
+            "同一关键词已经扫过（或正在扫），不该重复发起"
+        );
+        assert!(
+            !should_scan_after_input("  we  ", Some("we")),
+            "两端空白不该让同一个关键词被判定成「新关键词」而重复 SCAN"
+        );
+    }
+
+    #[test]
+    fn input_debounce_scans_the_server_for_a_new_keyword() {
+        assert!(
+            should_scan_after_input("we", None),
+            "首次输入关键词，停顿后应自动扫服务端（这正是用户不需要按回车的路径）"
+        );
+        assert!(
+            should_scan_after_input("web", Some("we")),
+            "关键词变化后要重新扫服务端"
+        );
+        assert!(
+            should_scan_after_input("key*", None),
+            "通配符关键词同样交给服务端，本地无法匹配"
         );
     }
 

--- a/crates/redis_view/src/redis_tree_view.rs
+++ b/crates/redis_view/src/redis_tree_view.rs
@@ -85,6 +85,8 @@ struct LocalSearchInput {
     has_matching_descendant: bool,
     is_load_more: bool,
     is_expanded: bool,
+    /// 连接 / 数据库这类结构锚点：过滤态下即使自身与子树都不匹配也要保留
+    is_structural: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -121,7 +123,11 @@ fn effective_tree_expansion(
 }
 
 fn local_search_visibility(input: LocalSearchInput) -> LocalSearchVisibility {
-    let include_node = !input.filter_active
+    // 过滤态下连接 / 数据库是结构锚点：即使它们与子树都不匹配也要保留。
+    // 否则整棵树会只剩空面板，用户看到的现象就是「搜不到 key」——分不清是
+    // 关键词没命中、键还没加载，还是搜索本身坏了。
+    let include_node = input.is_structural
+        || !input.filter_active
         || input.ancestor_matches
         || input.node_matches
         || input.is_load_more
@@ -133,6 +139,50 @@ fn local_search_visibility(input: LocalSearchInput) -> LocalSearchVisibility {
         descendants_inherit_match: input.filter_active
             && (input.ancestor_matches || input.node_matches),
     }
+}
+
+/// 计算本地过滤关键词。
+///
+/// 返回 `None` 表示「不过滤」，有两种情况：
+/// 1. 关键词为空；
+/// 2. 服务端已经按这个关键词扫描过——此时列表本身就是服务端的权威结果，
+///    不能再按树节点名二次过滤，否则跨命名空间命中的键会被误藏
+///    （例如 `*we*` 命中 `flow:east:1`，但节点名 `flow` / `east` 都不含 `we`）。
+fn search_filter_keyword(
+    search_keyword: &str,
+    server_search_keyword: Option<&str>,
+) -> Option<String> {
+    let keyword = search_keyword.trim();
+    if keyword.is_empty() {
+        return None;
+    }
+    if server_search_keyword == Some(keyword) {
+        return None;
+    }
+    // 含通配符的关键词只能交给服务端 SCAN，本地不做子串匹配。
+    if keyword.contains('*') || keyword.contains('?') || keyword.contains('[') {
+        return None;
+    }
+    Some(keyword.to_lowercase())
+}
+
+/// 解析一次搜索应该作用在哪些数据库节点上。
+///
+/// 搜索框属于整棵树而不是某一个节点，所以：
+/// - 选中能落到某个数据库时，只搜那一个库（保持原有语义）；
+/// - 否则回退到每个已连接连接的默认库，避免「没有选中节点 → 回车毫无反应」。
+fn resolve_search_targets(
+    selected_db_node: Option<String>,
+    fallback_db_nodes: impl IntoIterator<Item = String>,
+) -> Vec<String> {
+    if let Some(selected) = selected_db_node {
+        return vec![selected];
+    }
+
+    let mut targets: Vec<String> = fallback_db_nodes.into_iter().collect();
+    targets.sort();
+    targets.dedup();
+    targets
 }
 
 fn apply_redis_selection_state(
@@ -183,6 +233,10 @@ pub struct RedisTreeView {
     search_state: Entity<InputState>,
     /// 搜索关键词
     search_keyword: String,
+    /// 最近一次提交给服务端 SCAN 的关键词
+    ///
+    /// 与服务端结果配套：等于当前关键词时说明列表已是服务端权威结果，本地不再过滤。
+    server_search_keyword: Option<String>,
     /// 搜索请求序号（node_id -> token）
     search_tokens: HashMap<String, u64>,
     /// 数据库总键数（db_node_id -> total）
@@ -227,21 +281,7 @@ impl RedisTreeView {
             }
 
             if matches!(event, InputEvent::PressEnter { .. }) {
-                this.search_keyword = this.search_state.read(cx).text().to_string();
-                if let Some(node_id) = this.get_selected_refreshable_node() {
-                    if let Some(node) = this.nodes.get(&node_id) {
-                        if matches!(node.node_type, RedisNodeType::Database(_)) {
-                            let pattern = this.search_keyword.trim().to_string();
-                            if pattern.is_empty() {
-                                this.reset_db_key_count(&node_id);
-                                this.refresh_keys(node_id, cx);
-                            } else {
-                                cx.emit(RedisTreeViewEvent::SearchKeys { node_id, pattern });
-                            }
-                        }
-                    }
-                }
-                cx.notify();
+                this.trigger_search(cx);
             }
         })
         .detach();
@@ -255,6 +295,7 @@ impl RedisTreeView {
             context_menu_node_id: None,
             search_state,
             search_keyword: String::new(),
+            server_search_keyword: None,
             search_tokens: HashMap::new(),
             db_total_key_counts: HashMap::new(),
             selected_databases: HashMap::new(),
@@ -710,6 +751,11 @@ impl RedisTreeView {
                 format!("*{}*", trimmed)
             };
 
+        // 标记该关键词已交给服务端扫描：结果回来时列表本身就是权威结果，
+        // 本地不再按节点名二次过滤（否则跨命名空间的命中会被误藏）。
+        self.server_search_keyword = Some(trimmed.to_string());
+        self.rebuild_flat_entries();
+
         let token = self.bump_search_token(&node.id);
         self.load_keys(
             node.connection_id.clone(),
@@ -721,6 +767,57 @@ impl RedisTreeView {
             token,
             cx,
         );
+    }
+
+    /// 提交一次搜索：读取输入框、更新关键词状态并驱动服务端 SCAN。
+    ///
+    /// 回车与搜索按钮共用这一条路径，避免两个入口各自漂移。
+    fn trigger_search(&mut self, cx: &mut Context<Self>) {
+        self.search_keyword = self.search_state.read(cx).text().to_string();
+        let pattern = self.search_keyword.trim().to_string();
+        let targets = self.search_target_node_ids();
+
+        if pattern.is_empty() {
+            // 清空关键词 = 回到「列出全部键」，同时解除服务端结果标记。
+            self.server_search_keyword = None;
+            self.search_collapsed_nodes.clear();
+            for node_id in targets {
+                self.reset_db_key_count(&node_id);
+                self.refresh_keys(node_id, cx);
+            }
+            self.rebuild_flat_entries();
+            cx.notify();
+            return;
+        }
+
+        for node_id in targets {
+            cx.emit(RedisTreeViewEvent::SearchKeys {
+                node_id,
+                pattern: pattern.clone(),
+            });
+        }
+        self.rebuild_flat_entries();
+        cx.notify();
+    }
+
+    /// 本次搜索应该扫描哪些数据库节点
+    ///
+    /// 优先当前选中的库；若当前没有可用的选中库（例如还没点过任何节点），
+    /// 则回退到每个已连接连接的默认库，而不是静默什么都不做。
+    fn search_target_node_ids(&self) -> Vec<String> {
+        let selected_db = self.get_selected_refreshable_node().filter(|node_id| {
+            self.nodes
+                .get(node_id)
+                .is_some_and(|node| matches!(node.node_type, RedisNodeType::Database(_)))
+        });
+
+        let fallback = self.connected_nodes.iter().filter_map(|connection_id| {
+            let db_index = self.default_db_for_connection(connection_id);
+            let db_node_id = Self::db_node_id(connection_id, db_index);
+            self.nodes.contains_key(&db_node_id).then_some(db_node_id)
+        });
+
+        resolve_search_targets(selected_db, fallback)
     }
 
     /// 加载键列表
@@ -1422,6 +1519,52 @@ impl RedisTreeView {
         }
     }
 
+    /// 当前扁平列表里是否还有可见的键
+    fn has_visible_key(&self) -> bool {
+        self.flat_entries.iter().any(|entry| {
+            self.nodes
+                .get(&entry.node_id)
+                .is_some_and(|node| matches!(node.node_type, RedisNodeType::Key(_)))
+        })
+    }
+
+    /// 关键词非空但一个键都没显示出来时的提示语
+    ///
+    /// 区分「本地已加载的列表里没匹配」与「服务端也确认没有」：前者要引导用户
+    /// 回车扫描服务端，否则用户只会看到一片空白并认为搜索坏了。
+    fn search_empty_hint(&self) -> Option<String> {
+        let keyword = self.search_keyword.trim();
+        if keyword.is_empty() || self.has_visible_key() {
+            return None;
+        }
+
+        if self.server_search_keyword.as_deref() == Some(keyword) {
+            Some(t!("RedisTree.search_no_server_match", keyword = keyword).to_string())
+        } else {
+            Some(t!("RedisTree.search_no_local_match", keyword = keyword).to_string())
+        }
+    }
+
+    /// 列表为空时的兜底文案
+    fn empty_state_message(&self) -> String {
+        self.search_empty_hint()
+            .unwrap_or_else(|| t!("RedisTree.no_data").to_string())
+    }
+
+    /// 「没有匹配的键」提示条
+    fn render_search_hint(&self, hint: String, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .w_full()
+            .flex_shrink_0()
+            .px_2()
+            .py_1()
+            .border_t_1()
+            .border_color(cx.theme().border)
+            .text_sm()
+            .text_color(cx.theme().muted_foreground)
+            .child(hint)
+    }
+
     fn reset_db_key_count(&mut self, node_id: &str) {
         if let Some(total) = self.db_total_key_counts.get(node_id).copied() {
             if let Some(node) = self.nodes.get_mut(node_id) {
@@ -1555,7 +1698,7 @@ impl RedisTreeView {
 
     /// 折叠节点
     fn collapse_node(&mut self, node_id: &str, cx: &mut Context<Self>) {
-        if self.local_filter_keyword().is_some() {
+        if self.is_search_active() {
             self.search_collapsed_nodes.insert(node_id.to_string());
         }
         self.expanded_nodes.remove(node_id);
@@ -1652,11 +1795,18 @@ impl RedisTreeView {
     }
 
     fn is_node_expanded(&self, node_id: &str) -> bool {
+        // 展开策略看「是否处于搜索态」，而不是「是否在做本地名字过滤」：
+        // 服务端搜索期间本地过滤会关闭，但结果仍然需要自动铺开（issue #9）。
         effective_tree_expansion(
-            self.local_filter_keyword().is_some(),
+            self.is_search_active(),
             self.expanded_nodes.contains(node_id),
             self.search_collapsed_nodes.contains(node_id),
         )
+    }
+
+    /// 是否处于搜索态（关键词非空）
+    fn is_search_active(&self) -> bool {
+        !self.search_keyword.trim().is_empty()
     }
 
     /// 递归添加节点条目
@@ -1667,22 +1817,27 @@ impl RedisTreeView {
         match_cache: &mut HashMap<String, bool>,
     ) {
         let filter_keyword = self.local_filter_keyword();
-        let (_is_expandable, matches, child_ids, is_load_more) = match self.nodes.get(node_id) {
-            Some(node) => {
-                let is_load_more = matches!(node.node_type, RedisNodeType::LoadMore);
-                let matches = filter_keyword
-                    .as_ref()
-                    .map(|keyword| node.name.to_lowercase().contains(keyword))
-                    .unwrap_or(true);
-                let child_ids = node
-                    .children
-                    .iter()
-                    .map(|child| child.id.clone())
-                    .collect::<Vec<_>>();
-                (node.is_expandable(), matches, child_ids, is_load_more)
-            }
-            None => return,
-        };
+        let (_is_expandable, matches, child_ids, is_load_more, is_structural) =
+            match self.nodes.get(node_id) {
+                Some(node) => {
+                    let is_load_more = matches!(node.node_type, RedisNodeType::LoadMore);
+                    let is_structural = matches!(
+                        node.node_type,
+                        RedisNodeType::Connection | RedisNodeType::Database(_)
+                    );
+                    let matches = filter_keyword
+                        .as_ref()
+                        .map(|keyword| node.name.to_lowercase().contains(keyword))
+                        .unwrap_or(true);
+                    let child_ids = node
+                        .children
+                        .iter()
+                        .map(|child| child.id.clone())
+                        .collect::<Vec<_>>();
+                    (node.is_expandable(), matches, child_ids, is_load_more, is_structural)
+                }
+                None => return,
+            };
 
         let has_matching_descendant = filter_keyword.is_some()
             && !traversal.ancestor_matches
@@ -1696,6 +1851,7 @@ impl RedisTreeView {
             has_matching_descendant,
             is_load_more,
             is_expanded: self.is_node_expanded(node_id),
+            is_structural,
         });
         if !visibility.include_node {
             return;
@@ -1756,14 +1912,7 @@ impl RedisTreeView {
     }
 
     fn local_filter_keyword(&self) -> Option<String> {
-        let keyword = self.search_keyword.trim();
-        if keyword.is_empty() {
-            return None;
-        }
-        if keyword.contains('*') || keyword.contains('?') || keyword.contains('[') {
-            return None;
-        }
-        Some(keyword.to_lowercase())
+        search_filter_keyword(&self.search_keyword, self.server_search_keyword.as_deref())
     }
 
     fn get_node_icon(&self, node_type: &RedisNodeType) -> Icon {
@@ -1921,24 +2070,7 @@ impl RedisTreeView {
                     .tooltip(t!("RedisTree.search_help").to_string())
                     .on_click(move |_, _, cx| {
                         view_for_search.update(cx, |this, cx| {
-                            this.search_keyword = this.search_state.read(cx).text().to_string();
-                            if let Some(node_id) = this.get_selected_refreshable_node() {
-                                if let Some(node) = this.nodes.get(&node_id) {
-                                    if matches!(node.node_type, RedisNodeType::Database(_)) {
-                                        let pattern = this.search_keyword.trim().to_string();
-                                        if pattern.is_empty() {
-                                            this.reset_db_key_count(&node_id);
-                                            this.refresh_keys(node_id, cx);
-                                        } else {
-                                            cx.emit(RedisTreeViewEvent::SearchKeys {
-                                                node_id,
-                                                pattern,
-                                            });
-                                        }
-                                    }
-                                }
-                            }
-                            cx.notify();
+                            this.trigger_search(cx);
                         });
                     }),
             )
@@ -2702,8 +2834,9 @@ impl Render for RedisTreeView {
                         this.child(ContentState::loading(t!("RedisTree.loading").to_string()))
                     })
                     .when(!self.is_loading && entry_count == 0, |this| {
+                        // 搜索态下给出可操作提示，而不是笼统的「暂无数据」
                         this.child(
-                            ContentState::empty(t!("RedisTree.no_data").to_string())
+                            ContentState::empty(self.empty_state_message())
                                 .icon(
                                     Icon::new(IconName::Database)
                                         .color()
@@ -2713,8 +2846,9 @@ impl Render for RedisTreeView {
                         )
                     })
                     .when(!self.is_loading && entry_count > 0, |this| {
+                        let hint = self.search_empty_hint();
                         this.child(
-                            div()
+                            v_flex()
                                 .size_full()
                                 .context_menu({
                                     let view = cx.entity().clone();
@@ -2723,23 +2857,26 @@ impl Render for RedisTreeView {
                                     }
                                 })
                                 .child(
-                                    uniform_list(
-                                        "redis-tree-list",
-                                        entry_count,
-                                        cx.processor(
-                                            move |this: &mut Self,
-                                                  visible_range: std::ops::Range<usize>,
-                                                  window,
-                                                  cx| {
-                                                visible_range
-                                                    .map(|ix| this.render_item(ix, window, cx))
-                                                    .collect()
-                                            },
-                                        ),
-                                    )
-                                    .size_full()
-                                    .track_scroll(&self.scroll_handle),
-                                ),
+                                    div().flex_1().min_h_0().child(
+                                        uniform_list(
+                                            "redis-tree-list",
+                                            entry_count,
+                                            cx.processor(
+                                                move |this: &mut Self,
+                                                      visible_range: std::ops::Range<usize>,
+                                                      window,
+                                                      cx| {
+                                                    visible_range
+                                                        .map(|ix| this.render_item(ix, window, cx))
+                                                        .collect()
+                                                },
+                                            ),
+                                        )
+                                        .size_full()
+                                        .track_scroll(&self.scroll_handle),
+                                    ),
+                                )
+                                .children(hint.map(|hint| self.render_search_hint(hint, cx))),
                         )
                     }),
             )
@@ -2749,6 +2886,8 @@ impl Render for RedisTreeView {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui::{AppContext, TestAppContext, VisualTestContext, WindowOptions};
+    use gpui_component::Root;
 
     #[test]
     fn context_menu_target_updates_selection_and_clears_on_normal_selection() {
@@ -2851,6 +2990,7 @@ mod tests {
             has_matching_descendant: false,
             is_load_more: false,
             is_expanded: true,
+            is_structural: false,
         });
 
         assert!(visibility.include_node);
@@ -2859,6 +2999,44 @@ mod tests {
             "matched namespace should reveal its loaded children during search"
         );
         assert!(visibility.descendants_inherit_match);
+    }
+
+    /// issue #181：过滤态下连接 / 数据库是结构锚点，必须保留，否则整个面板
+    /// 会变空，用户分不清是没命中还是搜索坏了。
+    #[test]
+    fn filter_keeps_structural_nodes_even_when_nothing_matches() {
+        let visibility = local_search_visibility(LocalSearchInput {
+            filter_active: true,
+            ancestor_matches: false,
+            node_matches: false,
+            has_matching_descendant: false,
+            is_load_more: false,
+            is_expanded: true,
+            is_structural: true,
+        });
+
+        assert!(visibility.include_node, "连接/数据库节点不能整棵消失");
+        assert!(visibility.traverse_children);
+        assert!(
+            !visibility.descendants_inherit_match,
+            "结构锚点自身不匹配时，子节点仍需各自参与匹配"
+        );
+    }
+
+    #[test]
+    fn filter_still_hides_unmatched_key_nodes() {
+        let visibility = local_search_visibility(LocalSearchInput {
+            filter_active: true,
+            ancestor_matches: false,
+            node_matches: false,
+            has_matching_descendant: false,
+            is_load_more: false,
+            is_expanded: true,
+            is_structural: false,
+        });
+
+        assert!(!visibility.include_node);
+        assert!(!visibility.traverse_children);
     }
 
     #[test]
@@ -2870,6 +3048,7 @@ mod tests {
             has_matching_descendant: false,
             is_load_more: false,
             is_expanded: true,
+            is_structural: false,
         });
 
         assert!(visibility.include_node);
@@ -2907,5 +3086,165 @@ mod tests {
 
         assert_eq!(Some("auth"), auth.full_key.as_deref());
         assert_eq!(Some("auth:user"), user.full_key.as_deref());
+    }
+
+    #[test]
+    fn local_filter_is_skipped_once_the_server_scanned_the_same_keyword() {
+        assert_eq!(
+            Some("we".to_string()),
+            search_filter_keyword("we", None),
+            "未扫描服务端时，输入关键词应过滤已加载的列表"
+        );
+        assert_eq!(
+            None,
+            search_filter_keyword("we", Some("we")),
+            "服务端已按同一关键词扫描过，列表即权威结果，不能二次过滤"
+        );
+        assert_eq!(
+            Some("web".to_string()),
+            search_filter_keyword("web", Some("we")),
+            "关键词变化后重新回到本地过滤（在服务端结果上继续收窄）"
+        );
+        assert_eq!(None, search_filter_keyword("   ", Some("we")));
+        assert_eq!(
+            None,
+            search_filter_keyword("key*", None),
+            "含通配符的关键词只能交给服务端 SCAN"
+        );
+    }
+
+    #[test]
+    fn search_targets_prefer_the_selected_db_and_otherwise_cover_every_connected_db() {
+        assert_eq!(
+            vec!["conn:db1".to_string()],
+            resolve_search_targets(Some("conn:db1".to_string()), Vec::new()),
+            "有选中库时只搜它，保持原有语义"
+        );
+
+        let targets = resolve_search_targets(
+            None,
+            vec![
+                "b:db0".to_string(),
+                "a:db0".to_string(),
+                "b:db0".to_string(),
+            ],
+        );
+        assert_eq!(
+            vec!["a:db0".to_string(), "b:db0".to_string()],
+            targets,
+            "没有选中库时回退到所有已连接库，且顺序稳定、不重复"
+        );
+    }
+
+    /// issue #181：服务端 SCAN 命中「键名跨命名空间边界」的键时，不能再被本地
+    /// 名字过滤藏起来，否则用户看到的就是「搜不到 key」。
+    #[gpui::test]
+    fn server_search_results_are_not_hidden_by_the_local_filter(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            gpui_component::init(cx);
+            crate::init(cx);
+        });
+
+        let (window, tree) = cx.update(|cx| {
+            let mut tree = None;
+            let window = cx
+                .open_window(WindowOptions::default(), |window, cx| {
+                    let entity = cx.new(|cx| RedisTreeView::new(window, cx));
+                    tree = Some(entity.clone());
+                    cx.new(|cx| Root::new(entity, window, cx))
+                })
+                .expect("open redis tree test window");
+            (window, tree.expect("redis tree view"))
+        });
+
+        let db_node_id = RedisTreeView::db_node_id("conn", 0);
+        let mut cx = VisualTestContext::from_window(window.into(), cx);
+
+        tree.update_in(&mut cx, |tree, _window, cx| {
+            tree.connected_nodes.insert("conn".to_string());
+            tree.expanded_nodes.insert("conn".to_string());
+            tree.expanded_nodes.insert(db_node_id.clone());
+            tree.nodes.insert(
+                "conn".to_string(),
+                RedisNode::new(
+                    "conn",
+                    "redis-master",
+                    RedisNodeType::Connection,
+                    "conn",
+                    0,
+                ),
+            );
+            // 走真实挂载路径：set_current_database_node 也是把 db 节点挂到连接下
+            tree.set_node_children(
+                "conn",
+                vec![RedisNode::new(
+                    db_node_id.clone(),
+                    "db0",
+                    RedisNodeType::Database(0),
+                    "conn",
+                    0,
+                )],
+                cx,
+            );
+
+            // 服务端按 `*we*` 返回的键：`we` 跨过了 `:`，而树节点名
+            // `flow` / `east` / `1` 都不含 `we`。
+            let keys = RedisTreeView::build_namespace_tree(
+                "conn",
+                0,
+                vec![("flow:east:1".to_string(), RedisKeyType::String)],
+            );
+            tree.set_node_children(&db_node_id, keys, cx);
+
+            tree.search_keyword = "we".to_string();
+            tree.server_search_keyword = Some("we".to_string());
+            tree.rebuild_flat_entries();
+
+            assert_eq!(
+                vec!["flow:east:1".to_string()],
+                visible_key_names(tree),
+                "服务端已确认命中的键不能被本地名字过滤二次藏起来"
+            );
+            assert!(
+                visible_entry_ids(tree).contains(&db_node_id),
+                "过滤态下数据库锚点仍应可见"
+            );
+
+            // 对照分支：没有服务端扫描记录时，同一个键确实会被本地过滤隐藏。
+            // 没有这条断言，上面的断言就可能因为「根本没过滤」而空跑通过。
+            tree.server_search_keyword = None;
+            tree.rebuild_flat_entries();
+
+            assert!(
+                visible_key_names(tree).is_empty(),
+                "本地过滤（按节点名匹配）确实找不到这个键——这正是用户看到空列表的原因"
+            );
+            assert!(
+                visible_entry_ids(tree).contains(&db_node_id),
+                "即使一个键都不匹配，连接与数据库节点也不能消失"
+            );
+            assert!(
+                tree.search_empty_hint().is_some(),
+                "本地没匹配时要给出「回车扫描服务端」的可操作提示"
+            );
+        });
+        // 真正跑一遍 render：覆盖「无匹配提示条」这条新分支，确认不会 panic
+        cx.run_until_parked();
+    }
+
+    fn visible_entry_ids(tree: &RedisTreeView) -> Vec<String> {
+        tree.flat_entries
+            .iter()
+            .map(|entry| entry.node_id.clone())
+            .collect()
+    }
+
+    fn visible_key_names(tree: &RedisTreeView) -> Vec<String> {
+        tree.flat_entries
+            .iter()
+            .filter_map(|entry| tree.nodes.get(&entry.node_id))
+            .filter(|node| matches!(node.node_type, RedisNodeType::Key(_)))
+            .map(|node| node.full_key.clone().unwrap_or_else(|| node.name.clone()))
+            .collect()
     }
 }


### PR DESCRIPTION
## 问题（#181）

搜索框输入关键词后左侧树面板全空、搜不到键。根因是搜索链路上四个叠加缺陷，都在 `crates/redis_view/src/redis_tree_view.rs`：

1. **本地过滤叠在服务端结果上（主因）**：输入时按**单个树节点名**做子串过滤，回车/搜索按钮才走服务端 SCAN 按**整键**匹配。粒度不一致，于是 `*we*` 命中 `flow:east:1`（`we` 跨过了 `:`）这类键会被服务端返回、又被本地按节点名二次过滤藏掉。
2. **过滤态把整棵树清空**：`local_search_visibility` 会剔除「自身与子树都不匹配」的节点，连连接 / 数据库节点一起消失。而键列表是按需加载且上限 `SCAN_TARGET_KEYS = 500`，「本地没命中」是常态而非异常。
3. **搜索态自动展开被连带关掉**：issue #9 的「搜索时自动展开匹配路径」挂在「本地过滤生效」上，修好第 1 点后本地过滤关闭，展开也一起失效，服务端命中的键会折叠着看不见。
4. **回车/搜索按钮可能静默无动作**：两者都依赖 `get_selected_refreshable_node()`，没有可解析的选中库时什么都不做，也没有任何反馈。

## 改动

**修复上述四点**
- 新增 `server_search_keyword`（最近一次交给服务端 SCAN 的关键词）：与当前关键词相等时列表即权威结果，`local_filter_keyword()` 返回 `None` 不做二次过滤。
- `is_search_active()` 与本地过滤解耦，「搜索态自动展开」改用关键词非空判断。
- `LocalSearchInput.is_structural` 让连接 / 数据库作为结构锚点始终保留。
- 关键词非空但无可见键时给出可操作提示，区分「本地没匹配」与「服务端也没匹配」（en / zh-CN / zh-HK 三语）。
- 回车与搜索按钮收敛到 `trigger_search`，目标库用 `resolve_search_targets`（选中库优先，否则回退所有已连接库）。

**搜索改为输入停顿后自动扫服务端（对齐 Tiny RDM 的手感）**
- 新增 `SEARCH_INPUT_DEBOUNCE = 300ms`：输入瞬间先用本地已加载的键给出即时反馈，停顿后自动向服务端 SCAN 覆盖结果，不必再按回车；回车 / 搜索按钮仍是「立刻搜」。
- 新增纯函数 `should_scan_after_input`：空关键词或已扫过的关键词不重复发起。
- `trigger_search` 撤掉待触发的防抖，并**同步**写入「已交给服务端」标记 —— `emit` 是延迟 flush 的，等订阅方回写的话，回车后输入框补发的 `Change` 会再武装一次防抖并重复扫同一关键词。
- 清空搜索框立即恢复完整列表，不用等防抖。

## 验证

- `cargo test -p redis_view` → **59 passed / 0 failed**。
- 端到端测试用真实输入 + 真实定时器 + 真实事件（`simulate_input` / `focus` / `executor().advance_clock` / `cx.subscribe`）断言：停顿前 0 次请求、停顿后恰好 1 次（关键词正确）、回车立即搜且停顿到期不再补发。
- 真实节点树回归测试（`set_node_children` 搭树）：服务端命中的跨命名空间键不再被隐藏，且带「无服务端扫描记录时同一键确实被隐藏」的对照分支，防空跑。
- 变异验证（临时删改后测试必须转红）：去掉「免二次过滤」、去掉「结构锚点保留」、去掉「搜索态展开」、去掉「输入后自动搜索」、去掉「提交时同步标记」、把防抖时长改成 0 —— 全部转红。
- 另有一个对照分支测试证明 `drop(Task)` 会取消未到期的定时器（不 drop 时必然执行）；据此明确了「替换 `Option<Task>` 即完成取消」，并删掉了先前多写的代次守卫（变异验证确认它是死代码）。
- `cargo clippy -p redis_view --all-targets`：仅 2 条既有告警（`load_keys` 参数过多、事件枚举体积差），与改动前完全一致。
- `cargo fmt`：本次改动文件未新增格式问题（`redis_tree_view.rs` 仍有 3 处改动前就存在的格式差异，位置与改动前一致）。

Fixes #181
