### PR TITLE
feat(ai_chat): support custom system prompt for built-in Agent (fix #173)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5073,7 +5073,7 @@ dependencies = [
 [[package]]
 name = "gpui-base"
 version = "0.6.1"
-source = "git+https://github.com/feigeCode/gpui-component?rev=254bfe496252d8e0aa9aa38086b28edaeec98eb5#254bfe496252d8e0aa9aa38086b28edaeec98eb5"
+source = "git+https://github.com/feigeCode/gpui-component?rev=cea6f302c9833909c5d564ea5dda59a60a2655b3#cea6f302c9833909c5d564ea5dda59a60a2655b3"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -5107,7 +5107,7 @@ dependencies = [
 [[package]]
 name = "gpui-component"
 version = "0.6.1"
-source = "git+https://github.com/feigeCode/gpui-component?rev=254bfe496252d8e0aa9aa38086b28edaeec98eb5#254bfe496252d8e0aa9aa38086b28edaeec98eb5"
+source = "git+https://github.com/feigeCode/gpui-component?rev=cea6f302c9833909c5d564ea5dda59a60a2655b3#cea6f302c9833909c5d564ea5dda59a60a2655b3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5157,7 +5157,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-macros"
 version = "0.6.1"
-source = "git+https://github.com/feigeCode/gpui-component?rev=254bfe496252d8e0aa9aa38086b28edaeec98eb5#254bfe496252d8e0aa9aa38086b28edaeec98eb5"
+source = "git+https://github.com/feigeCode/gpui-component?rev=cea6f302c9833909c5d564ea5dda59a60a2655b3#cea6f302c9833909c5d564ea5dda59a60a2655b3"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-shell"
 version = "0.6.1"
-source = "git+https://github.com/feigeCode/gpui-component?rev=254bfe496252d8e0aa9aa38086b28edaeec98eb5#254bfe496252d8e0aa9aa38086b28edaeec98eb5"
+source = "git+https://github.com/feigeCode/gpui-component?rev=cea6f302c9833909c5d564ea5dda59a60a2655b3#cea6f302c9833909c5d564ea5dda59a60a2655b3"
 dependencies = [
  "gpui-component",
  "gpui-shell",
@@ -5177,7 +5177,7 @@ dependencies = [
 [[package]]
 name = "gpui-fps"
 version = "0.6.1"
-source = "git+https://github.com/feigeCode/gpui-component?rev=254bfe496252d8e0aa9aa38086b28edaeec98eb5#254bfe496252d8e0aa9aa38086b28edaeec98eb5"
+source = "git+https://github.com/feigeCode/gpui-component?rev=cea6f302c9833909c5d564ea5dda59a60a2655b3#cea6f302c9833909c5d564ea5dda59a60a2655b3"
 dependencies = [
  "core-graphics 0.24.0",
  "gpui-pre",
@@ -5194,7 +5194,7 @@ dependencies = [
 [[package]]
 name = "gpui-kit-assets"
 version = "0.6.1"
-source = "git+https://github.com/feigeCode/gpui-component?rev=254bfe496252d8e0aa9aa38086b28edaeec98eb5#254bfe496252d8e0aa9aa38086b28edaeec98eb5"
+source = "git+https://github.com/feigeCode/gpui-component?rev=cea6f302c9833909c5d564ea5dda59a60a2655b3#cea6f302c9833909c5d564ea5dda59a60a2655b3"
 dependencies = [
  "anyhow",
  "gpui-pre",
@@ -5716,7 +5716,7 @@ dependencies = [
 [[package]]
 name = "gpui-shell"
 version = "0.6.1"
-source = "git+https://github.com/feigeCode/gpui-component?rev=254bfe496252d8e0aa9aa38086b28edaeec98eb5#254bfe496252d8e0aa9aa38086b28edaeec98eb5"
+source = "git+https://github.com/feigeCode/gpui-component?rev=cea6f302c9833909c5d564ea5dda59a60a2655b3#cea6f302c9833909c5d564ea5dda59a60a2655b3"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5748,7 +5748,7 @@ dependencies = [
 [[package]]
 name = "gpui-wry"
 version = "0.6.1"
-source = "git+https://github.com/feigeCode/gpui-component?rev=254bfe496252d8e0aa9aa38086b28edaeec98eb5#254bfe496252d8e0aa9aa38086b28edaeec98eb5"
+source = "git+https://github.com/feigeCode/gpui-component?rev=cea6f302c9833909c5d564ea5dda59a60a2655b3#cea6f302c9833909c5d564ea5dda59a60a2655b3"
 dependencies = [
  "anyhow",
  "gpui-pre",
@@ -11768,7 +11768,7 @@ dependencies = [
 [[package]]
 name = "rquickjs"
 version = "0.12.7"
-source = "git+https://github.com/feigeCode/gpui-component?rev=254bfe496252d8e0aa9aa38086b28edaeec98eb5#254bfe496252d8e0aa9aa38086b28edaeec98eb5"
+source = "git+https://github.com/feigeCode/gpui-component?rev=cea6f302c9833909c5d564ea5dda59a60a2655b3#cea6f302c9833909c5d564ea5dda59a60a2655b3"
 dependencies = [
  "quickjs-jit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,13 +56,13 @@ edition = "2024"
 # the workspace resolves it from GitHub instead of a sibling ../gpui-component
 # checkout. The dependency keys keep the crate names navop already imports
 # (`gpui_component`, `gpui_base`, `gpui_shell`, ...).
-gpui-component = { git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
-gpui-component-assets = { package = "gpui-kit-assets", git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
-gpui-base = { git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
-gpui-shell = { git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
-gpui-component-shell = { git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
-gpui-wry = { git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
-gpui-kit = { git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
+gpui-component = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
+gpui-component-assets = { package = "gpui-kit-assets", git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
+gpui-base = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
+gpui-shell = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
+gpui-component-shell = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
+gpui-wry = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
+gpui-kit = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
 
 gpui = { package = "gpui-pre", version = "0.3.1" }
 gpui_platform = { package = "gpui-pre-platform", version = "0.3.1", features = ["font-kit", "x11", "wayland", "runtime_shaders"] }
@@ -357,4 +357,4 @@ gpui-pre-ztracing-macro    = { git = "https://github.com/feigeCode/gpui-pre.git"
 # live in this root manifest: [patch] sections inside the gpui-component
 # workspace are ignored by cargo. Mirrors the same entry in gpui-component's
 # workspace root, pinned to the same revision as the gpui dependencies above.
-rquickjs = { git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
+rquickjs = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,13 +56,13 @@ edition = "2024"
 # the workspace resolves it from GitHub instead of a sibling ../gpui-component
 # checkout. The dependency keys keep the crate names navop already imports
 # (`gpui_component`, `gpui_base`, `gpui_shell`, ...).
-gpui-component = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
-gpui-component-assets = { package = "gpui-kit-assets", git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
-gpui-base = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
-gpui-shell = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
-gpui-component-shell = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
-gpui-wry = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
-gpui-kit = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
+gpui-component = { git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
+gpui-component-assets = { package = "gpui-kit-assets", git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
+gpui-base = { git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
+gpui-shell = { git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
+gpui-component-shell = { git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
+gpui-wry = { git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
+gpui-kit = { git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }
 
 gpui = { package = "gpui-pre", version = "0.3.1" }
 gpui_platform = { package = "gpui-pre-platform", version = "0.3.1", features = ["font-kit", "x11", "wayland", "runtime_shaders"] }
@@ -357,4 +357,4 @@ gpui-pre-ztracing-macro    = { git = "https://github.com/feigeCode/gpui-pre.git"
 # live in this root manifest: [patch] sections inside the gpui-component
 # workspace are ignored by cargo. Mirrors the same entry in gpui-component's
 # workspace root, pinned to the same revision as the gpui dependencies above.
-rquickjs = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
+rquickjs = { git = "https://github.com/feigeCode/gpui-component", rev = "460f5c50b2f123ef4fd4a4b8a974f6c53d137ee8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,13 +56,13 @@ edition = "2024"
 # the workspace resolves it from GitHub instead of a sibling ../gpui-component
 # checkout. The dependency keys keep the crate names navop already imports
 # (`gpui_component`, `gpui_base`, `gpui_shell`, ...).
-gpui-component = { git = "https://github.com/feigeCode/gpui-component", rev = "254bfe496252d8e0aa9aa38086b28edaeec98eb5" }
-gpui-component-assets = { package = "gpui-kit-assets", git = "https://github.com/feigeCode/gpui-component", rev = "254bfe496252d8e0aa9aa38086b28edaeec98eb5" }
-gpui-base = { git = "https://github.com/feigeCode/gpui-component", rev = "254bfe496252d8e0aa9aa38086b28edaeec98eb5" }
-gpui-shell = { git = "https://github.com/feigeCode/gpui-component", rev = "254bfe496252d8e0aa9aa38086b28edaeec98eb5" }
-gpui-component-shell = { git = "https://github.com/feigeCode/gpui-component", rev = "254bfe496252d8e0aa9aa38086b28edaeec98eb5" }
-gpui-wry = { git = "https://github.com/feigeCode/gpui-component", rev = "254bfe496252d8e0aa9aa38086b28edaeec98eb5" }
-gpui-kit = { git = "https://github.com/feigeCode/gpui-component", rev = "254bfe496252d8e0aa9aa38086b28edaeec98eb5" }
+gpui-component = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
+gpui-component-assets = { package = "gpui-kit-assets", git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
+gpui-base = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
+gpui-shell = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
+gpui-component-shell = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
+gpui-wry = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
+gpui-kit = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }
 
 gpui = { package = "gpui-pre", version = "0.3.1" }
 gpui_platform = { package = "gpui-pre-platform", version = "0.3.1", features = ["font-kit", "x11", "wayland", "runtime_shaders"] }
@@ -357,4 +357,4 @@ gpui-pre-ztracing-macro    = { git = "https://github.com/feigeCode/gpui-pre.git"
 # live in this root manifest: [patch] sections inside the gpui-component
 # workspace are ignored by cargo. Mirrors the same entry in gpui-component's
 # workspace root, pinned to the same revision as the gpui dependencies above.
-rquickjs = { git = "https://github.com/feigeCode/gpui-component", rev = "254bfe496252d8e0aa9aa38086b28edaeec98eb5" }
+rquickjs = { git = "https://github.com/feigeCode/gpui-component", rev = "cea6f302c9833909c5d564ea5dda59a60a2655b3" }

--- a/crates/ai_chat_view/src/agent_view.rs
+++ b/crates/ai_chat_view/src/agent_view.rs
@@ -855,6 +855,12 @@ pub struct AgentChatView {
     is_running: bool,
     /// 系统提示词（可选，用于自定义 AI 行为）。
     system_instruction: Option<String>,
+    /// 当前指令是否来自全局设置的自定义系统提示词。
+    ///
+    /// 用于区分「设置种子值」与外部显式调用 [`Self::set_system_instruction`]
+    /// 注入的指令（如终端侧边栏的连接上下文指令）：前者在新会话时跟随设置
+    /// 刷新，后者保持不变。
+    system_instruction_from_settings: bool,
     /// 代码块操作注册表。
     code_block_actions: CodeBlockActionRegistry,
     /// 可选的局部聊天主题。
@@ -978,6 +984,11 @@ impl AgentChatView {
 
         let tool_execution_mode =
             runtime_tool_execution_mode(AppSettings::current(cx).ai_chat.tool_execution_mode);
+        // 全局自定义系统提示词：仅在没有任何指令时作为种子值，保证外部调用方
+        // 通过 pending_system_instruction 注入的指令不被覆盖。
+        let seed_system_instruction =
+            AppSettings::current(cx).ai_chat.effective_custom_system_prompt();
+        let system_instruction_from_settings = seed_system_instruction.is_some();
         let tool_options = default_tool_options();
 
         let skills = AgentSkillState::load_default();
@@ -1028,7 +1039,7 @@ impl AgentChatView {
             false,
         );
 
-        Self {
+        let mut new_view = Self {
             runtime,
             session_id,
             resources,
@@ -1076,14 +1087,19 @@ impl AgentChatView {
             tool_options,
             runtime_factory,
             is_running: false,
-            system_instruction: None,
+            system_instruction: seed_system_instruction,
+            system_instruction_from_settings,
             theme,
             code_block_actions: CodeBlockActionRegistry::new(),
             _subscriptions: subscriptions,
             _event_task: event_task,
             _acp_permission_task: None,
             _acp_public_mcp_approval_task: None,
+        };
+        if new_view.system_instruction.is_some() {
+            new_view.apply_system_instruction_to_current_session();
         }
+        new_view
     }
 
     fn register_approval_actions(cx: &mut Context<Self>) {
@@ -2639,6 +2655,11 @@ impl AgentChatView {
                 self.persist_current(cx);
                 self.runtime = binding.runtime;
                 self.session_id = binding.session_id;
+                if self.system_instruction_from_settings {
+                    self.system_instruction =
+                        AppSettings::current(cx).ai_chat.effective_custom_system_prompt();
+                    self.system_instruction_from_settings = self.system_instruction.is_some();
+                }
                 self.apply_system_instruction_to_current_session();
                 self.sync_session_skills();
                 self.selected_model = binding.selected_model;
@@ -2839,6 +2860,12 @@ impl AgentChatView {
         self.stash_current_transcript();
         let session = self.runtime.create_session(self.resources.clone());
         self.session_id = session.id().clone();
+        if self.system_instruction_from_settings {
+            // 新会话跟随设置的最新值；外部显式指令保持不变。
+            self.system_instruction =
+                AppSettings::current(cx).ai_chat.effective_custom_system_prompt();
+            self.system_instruction_from_settings = self.system_instruction.is_some();
+        }
         self.apply_system_instruction_to_current_session();
         self.sync_session_skills();
         self.current_session = self.session_id.to_string();
@@ -3064,8 +3091,18 @@ impl AgentChatView {
         };
         self.closed_sessions.remove(uid);
         self.session_id = target.id().clone();
-        self.system_instruction = target.system_instruction();
+        // 快照自带指令的会话优先快照值（行为可复现）；没有指令的旧会话回落到
+        // 当前全局设置，让存量会话也能享受新配置。
+        self.system_instruction = target.system_instruction().or_else(|| {
+            AppSettings::current(cx).ai_chat.effective_custom_system_prompt()
+        });
+        self.system_instruction_from_settings =
+            self.system_instruction.is_some()
+                && target.system_instruction().is_none();
         self.current_session = self.session_id.to_string();
+        if let Some(session) = self.runtime.session(&self.session_id) {
+            session.set_system_instruction(self.system_instruction.clone());
+        }
         if let Some(transcript) = self.remove_cached_session_transcript(uid) {
             self.transcript = transcript;
         } else {
@@ -3217,6 +3254,7 @@ impl AgentChatView {
     /// 设置系统提示词（用于自定义 AI 行为）。
     pub fn set_system_instruction(&mut self, instruction: Option<String>, cx: &mut Context<Self>) {
         self.system_instruction = instruction.clone();
+        self.system_instruction_from_settings = false;
         self.apply_system_instruction_to_current_session();
         cx.notify();
     }
@@ -8276,6 +8314,107 @@ mod tests {
                 .content_as_text()
                 .contains("始终用 DBA 视角回答。")
         );
+    }
+
+    #[gpui::test]
+    fn gpui_custom_system_prompt_from_settings_seeds_new_view(cx: &mut TestAppContext) {
+        init_test_ui(cx);
+        cx.update(|cx| {
+            let mut settings = AppSettings::default();
+            settings.ai_chat.custom_system_prompt = "  始终用 DBA 视角回答。\n".into();
+            cx.set_global(settings);
+        });
+        let model = Arc::new(MockModelClient::new([ModelResponse::text("好的。")]));
+        let runtime = test_runtime_with_model(model.clone());
+        let config = AgentChatViewConfig::new(runtime, ResourceContext::new(), vec![]);
+
+        let (view, cx) =
+            cx.add_window_view(move |window, cx| AgentChatView::new(config, window, cx));
+        view.update_in(cx, |view, window, cx| {
+            let input = view.input.clone();
+            view.on_input_event(
+                &input,
+                &AgentInputEvent::Submit {
+                    text: "解释一下索引".into(),
+                    mentions: Vec::new(),
+                    images: Vec::new(),
+                },
+                window,
+                cx,
+            );
+        });
+        run_gpui_until(cx, || model.request_count() >= 1);
+
+        let requests = model.received_requests();
+        assert!(requests[0].messages[0]
+            .content_as_text()
+            .contains("始终用 DBA 视角回答。"));
+    }
+
+    #[gpui::test]
+    fn gpui_external_system_instruction_wins_over_settings_seed(cx: &mut TestAppContext) {
+        init_test_ui(cx);
+        cx.update(|cx| {
+            let mut settings = AppSettings::default();
+            settings.ai_chat.custom_system_prompt = "设置里的人设。".into();
+            cx.set_global(settings);
+        });
+        let model = Arc::new(MockModelClient::new([ModelResponse::text("好的。")]));
+        let runtime = test_runtime_with_model(model.clone());
+        let config = AgentChatViewConfig::new(runtime, ResourceContext::new(), vec![]);
+
+        let (view, cx) =
+            cx.add_window_view(move |window, cx| AgentChatView::new(config, window, cx));
+        view.update_in(cx, |view, window, cx| {
+            view.set_system_instruction(Some("外部显式指令。".into()), cx);
+            let input = view.input.clone();
+            view.on_input_event(
+                &input,
+                &AgentInputEvent::Submit {
+                    text: "解释一下索引".into(),
+                    mentions: Vec::new(),
+                    images: Vec::new(),
+                },
+                window,
+                cx,
+            );
+        });
+        run_gpui_until(cx, || model.request_count() >= 1);
+
+        let requests = model.received_requests();
+        let prompt = requests[0].messages[0].content_as_text();
+        assert!(prompt.contains("外部显式指令。"));
+        assert!(!prompt.contains("设置里的人设。"));
+    }
+
+    #[gpui::test]
+    fn gpui_session_switch_restores_snapshot_instruction_for_local_sessions(
+        cx: &mut TestAppContext,
+    ) {
+        init_test_ui(cx);
+        let runtime = test_runtime("m");
+        let config = AgentChatViewConfig::new(runtime.clone(), ResourceContext::new(), vec![]);
+
+        let (view, cx) =
+            cx.add_window_view(move |window, cx| AgentChatView::new(config, window, cx));
+        let first_id = view.read_with(cx, |view, _| view.session_id.clone());
+        view.update(cx, |view, cx| {
+            // 第一个会话带外部显式指令（模拟旧版行为），随后新建第二个会话。
+            view.set_system_instruction(Some("旧会话指令。".into()), cx);
+            view.start_fresh_session(cx);
+        });
+        let second_id = view.read_with(cx, |view, _| view.session_id.clone());
+        assert_ne!(first_id, second_id);
+
+        // 切回第一个会话：快照值优先，且外部指令不被全局设置覆盖。
+        view.update(cx, |view, cx| {
+            view.switch_session(&first_id.to_string(), cx);
+        });
+        view.read_with(cx, |view, _| {
+            assert!(!view.system_instruction_from_settings);
+        });
+        let session = runtime.session(&first_id).expect("session should exist");
+        assert_eq!(session.system_instruction().as_deref(), Some("旧会话指令。"));
     }
 
     #[gpui::test]

--- a/crates/ai_chat_view/src/agent_view.rs
+++ b/crates/ai_chat_view/src/agent_view.rs
@@ -1039,7 +1039,7 @@ impl AgentChatView {
             false,
         );
 
-        let mut new_view = Self {
+        let new_view = Self {
             runtime,
             session_id,
             resources,

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -547,6 +547,31 @@ pub struct AiChatSettings {
         deserialize_with = "deserialize_agent_max_iterations"
     )]
     pub max_iterations: usize,
+    /// 用户自定义系统提示词（追加在内置 Agent 基座提示词之后）。
+    ///
+    /// 空串表示未启用；旧配置缺少该字段时按空串回落。
+    #[serde(default)]
+    pub custom_system_prompt: String,
+}
+
+/// 自定义系统提示词的最大字符数（按 chars 计），防止拖垮上下文长度。
+pub const MAX_CUSTOM_SYSTEM_PROMPT_CHARS: usize = 8000;
+
+impl AiChatSettings {
+    /// 返回规范化后的自定义系统提示词；空白内容返回 `None`。
+    ///
+    /// 超长内容按 [`MAX_CUSTOM_SYSTEM_PROMPT_CHARS`] 截断，避免配置文件里
+    /// 的异常值直接拖垮每次请求的上下文。
+    pub fn effective_custom_system_prompt(&self) -> Option<String> {
+        let trimmed = self.custom_system_prompt.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        if trimmed.chars().count() <= MAX_CUSTOM_SYSTEM_PROMPT_CHARS {
+            return Some(trimmed.to_string());
+        }
+        Some(trimmed.chars().take(MAX_CUSTOM_SYSTEM_PROMPT_CHARS).collect())
+    }
 }
 
 fn default_agent_max_iterations() -> usize {
@@ -566,6 +591,7 @@ impl Default for AiChatSettings {
         Self {
             tool_execution_mode: AiChatToolExecutionMode::default(),
             max_iterations: default_agent_max_iterations(),
+            custom_system_prompt: String::new(),
         }
     }
 }
@@ -1631,6 +1657,7 @@ mod tests {
 
     use super::{
         AiChatSettings, AiChatToolExecutionMode, AppSettings, ConnectionSortOrder, CustomFont,
+        MAX_CUSTOM_SYSTEM_PROMPT_CHARS,
         DEFAULT_MCP_APPROVAL_TIMEOUT_MS, DEFAULT_TERMINAL_THEME, HomeConnectionLayout,
         LOCALE_SYSTEM, LargeTextCellEditorOpenMode, LocalTerminalProfileKind,
         LocalTerminalProfileSettings, MainWindowState, McpPermissionMode, McpServerMode,
@@ -2027,6 +2054,48 @@ mod tests {
         // 旧配置文件缺少该字段时应回落到 100%。
         let legacy: AppSettings = serde_json::from_str("{}").expect("旧配置应能读取");
         assert_eq!(100, legacy.ui_scale_percent);
+    }
+
+    #[test]
+    fn ai_chat_custom_system_prompt_defaults_to_empty_for_legacy_configs() {
+        let settings: AiChatSettings =
+            serde_json::from_str(r#"{ "max_iterations": 32 }"#).expect("旧配置应能读取");
+        assert_eq!(String::new(), settings.custom_system_prompt);
+        assert_eq!(None, settings.effective_custom_system_prompt());
+    }
+
+    #[test]
+    fn ai_chat_custom_system_prompt_trims_blank_values_to_none() {
+        let mut settings = AiChatSettings::default();
+        settings.custom_system_prompt = "   ".to_string();
+        assert_eq!(None, settings.effective_custom_system_prompt());
+
+        settings.custom_system_prompt = "  始终用 DBA 视角回答。\n".to_string();
+        assert_eq!(
+            Some("始终用 DBA 视角回答。".to_string()),
+            settings.effective_custom_system_prompt()
+        );
+    }
+
+    #[test]
+    fn ai_chat_custom_system_prompt_clamps_overlong_values() {
+        let mut settings = AiChatSettings::default();
+        settings.custom_system_prompt = "好".repeat(MAX_CUSTOM_SYSTEM_PROMPT_CHARS + 100);
+        let effective = settings
+            .effective_custom_system_prompt()
+            .expect("非空内容应返回 Some");
+        assert_eq!(MAX_CUSTOM_SYSTEM_PROMPT_CHARS, effective.chars().count());
+
+        // 边界长度不截断。
+        settings.custom_system_prompt = "x".repeat(MAX_CUSTOM_SYSTEM_PROMPT_CHARS);
+        assert_eq!(
+            MAX_CUSTOM_SYSTEM_PROMPT_CHARS,
+            settings
+                .effective_custom_system_prompt()
+                .expect("边界长度应返回 Some")
+                .chars()
+                .count()
+        );
     }
 
     #[test]

--- a/crates/db_view/src/sql_editor_view.rs
+++ b/crates/db_view/src/sql_editor_view.rs
@@ -34,8 +34,8 @@ use gpui::{
 use gpui_component::button::{Button, ButtonCustomVariant, ButtonVariants};
 use gpui_component::dialog::DialogFooter;
 use gpui_component::input::{
-    GutterMarker, InlineWidgetCollection, Input, InputEvent, InputState, RangeDecoration,
-    RangeDecorationCollection, RangeDecorationStyle,
+    GutterMarker, Input, InputEvent, InputState, RangeDecoration, RangeDecorationCollection,
+    RangeDecorationStyle,
 };
 use gpui_component::notification::Notification;
 use gpui_component::select::{SearchableVec, Select, SelectEvent, SelectItem, SelectState};
@@ -1418,8 +1418,6 @@ pub struct SqlEditorTab {
     last_insert_hints_key: Option<(usize, u64)>,
     /// 当前语句框装饰集合（随编辑自动跟踪范围）。
     range_decorations: RangeDecorationCollection,
-    /// 行内 widget 集合（INSERT 值提示等）。
-    inline_widgets: InlineWidgetCollection,
     /// 与 gutter lane 标记顺序一致的 marker id，用于把点击事件映射回语句。
     gutter_marker_ids: Vec<String>,
 }
@@ -1513,9 +1511,6 @@ impl SqlEditorTab {
         let range_decorations = input.update(cx, |state, cx| {
             state.create_range_decorations_collection(Vec::new(), cx)
         });
-        let inline_widgets = input.update(cx, |state, cx| {
-            state.create_inline_widgets_collection(Vec::new(), cx)
-        });
         let mut instance = Self {
             title: config.title,
             editor: editor.clone(),
@@ -1563,7 +1558,6 @@ impl SqlEditorTab {
             insert_values_highlight: None,
             last_insert_hints_key: None,
             range_decorations,
-            inline_widgets,
             gutter_marker_ids: Vec::new(),
         };
 
@@ -1897,7 +1891,6 @@ impl SqlEditorTab {
         else {
             self.insert_values_highlight = None;
             self.last_insert_hints_key = None;
-            self.inline_widgets.clear(cx);
             return;
         };
         if self.last_insert_hints_key == Some((statement_start, revision)) {
@@ -1918,7 +1911,6 @@ impl SqlEditorTab {
 
         self.insert_values_highlight = values_highlight;
 
-        self.inline_widgets.clear(cx);
         self.refresh_current_statement_frame(cx);
     }
 
@@ -4740,7 +4732,6 @@ impl Clone for SqlEditorTab {
             insert_values_highlight: self.insert_values_highlight.clone(),
             last_insert_hints_key: self.last_insert_hints_key,
             range_decorations: self.range_decorations.clone(),
-            inline_widgets: self.inline_widgets.clone(),
             gutter_marker_ids: self.gutter_marker_ids.clone(),
         }
     }

--- a/crates/extension-runtime/src/lib.rs
+++ b/crates/extension-runtime/src/lib.rs
@@ -30,6 +30,7 @@ pub use types::{
     RegisteredDocumentExporter, RegisteredIpcRuntimeBinding, RegisteredRemoteFileEditorCommand,
     RegisteredRemoteFileEditorContribution, RegisteredResourceConnectionContribution,
     RegisteredResourceWorkbenchContribution, RegisteredShellViewContribution,
+    WorkbenchOperationCatalog, WorkbenchOperationEntry, WorkbenchOperationParam,
 };
 
 #[cfg(all(test, feature = "wasm-components"))]

--- a/main/locales/main.yml
+++ b/main/locales/main.yml
@@ -2912,6 +2912,18 @@ Settings:
         en: Maximum Iterations
         zh-CN: 最大迭代次数
         zh-HK: 最大迭代次數
+      custom_system_prompt:
+        en: Custom System Prompt
+        zh-CN: 自定义系统提示词
+        zh-HK: 自訂系統提示詞
+      custom_system_prompt_desc:
+        en: Extra persona or domain rules appended after the built-in agent prompt; applies to new built-in Agent sessions (not ACP/external agents). Leave empty to disable. Up to 8000 characters.
+        zh-CN: 追加在内置 Agent 提示词之后的人设或领域规则，对新的内置 Agent 会话生效（不影响 ACP 外部 Agent）。留空表示不启用，最长 8000 字符。
+        zh-HK: 附加在內置 Agent 提示詞之後的人設或領域規則，對新的內置 Agent 會話生效（不影響 ACP 外部 Agent）。留空表示不啟用，最長 8000 字符。
+      custom_system_prompt_placeholder:
+        en: e.g. Always answer as a senior DBA; keep replies in bullet points...
+        zh-CN: 例如：始终以资深 DBA 视角回答；回答保持要点式……
+        zh-HK: 例如：始終以資深 DBA 視角回答；回答保持要點式……
       max_iterations_desc:
         en: Maximum model and tool round trips in one built-in Agent turn (1-256). Changes apply from the next turn.
         zh-CN: 内置 Agent 单轮中模型与工具调用的最大往返次数（1-256）。修改从下一轮开始生效。

--- a/main/src/settings/agent_settings.rs
+++ b/main/src/settings/agent_settings.rs
@@ -1,8 +1,10 @@
 use agent_runtime::{
     DEFAULT_AGENT_MAX_ITERATIONS, MAX_AGENT_MAX_ITERATIONS, MIN_AGENT_MAX_ITERATIONS,
 };
-use gpui::App;
+use gpui::{App, AppContext, Context, Entity, IntoElement, ParentElement, Styled, Window};
+use gpui_component::input::{InputEvent, Textarea, TextareaState};
 use gpui_component::setting::{NumberFieldOptions, SettingField, SettingGroup, SettingItem};
+use gpui_component::{ActiveTheme, v_flex};
 use one_core::settings::{AiChatSettings, AppSettings};
 use rust_i18n::t;
 
@@ -29,6 +31,66 @@ pub fn agent_setting_group(default_settings: &AiChatSettings) -> SettingGroup {
             )
             .description(t!("Settings.General.Agent.max_iterations_desc").to_string()),
         )
+        .item(custom_system_prompt_item())
+}
+
+fn custom_system_prompt_item() -> SettingItem {
+    SettingItem::render(|_options, window, cx| render_custom_system_prompt(window, cx)).keywords([
+        t!("Settings.General.Agent.custom_system_prompt").to_string(),
+        t!("Settings.General.Agent.custom_system_prompt_desc").to_string(),
+    ])
+}
+
+struct CustomSystemPromptEditor {
+    input: Entity<TextareaState>,
+    _subscription: gpui::Subscription,
+}
+
+fn render_custom_system_prompt(window: &mut Window, cx: &mut App) -> gpui::AnyElement {
+    let editor = window.use_keyed_state("agent-custom-system-prompt", cx, |window, cx| {
+        CustomSystemPromptEditor::new(window, cx)
+    });
+    editor.into_any_element()
+}
+
+impl CustomSystemPromptEditor {
+    fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let input = cx.new(|cx| {
+            TextareaState::new(window, cx)
+                .auto_grow(4, 12)
+                .placeholder(t!("Settings.General.Agent.custom_system_prompt_placeholder"))
+                .default_value(AppSettings::global(cx).ai_chat.custom_system_prompt.clone())
+        });
+        let subscription = cx.subscribe(&input, |editor: &mut Self, _, event: &InputEvent, cx| {
+            if matches!(event, InputEvent::Change) {
+                let value = editor.input.read(cx).value().to_string();
+                AppSettings::update_and_save(cx, |settings| {
+                    settings.ai_chat.custom_system_prompt = value;
+                });
+                cx.notify();
+            }
+        });
+        Self {
+            input,
+            _subscription: subscription,
+        }
+    }
+}
+
+impl gpui::Render for CustomSystemPromptEditor {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl gpui::IntoElement {
+        v_flex()
+            .w_full()
+            .max_w(gpui::px(640.))
+            .gap_2()
+            .child(
+                gpui::div()
+                    .text_sm()
+                    .text_color(cx.theme().muted_foreground)
+                    .child(t!("Settings.General.Agent.custom_system_prompt_desc").to_string()),
+            )
+            .child(Textarea::new(&self.input))
+    }
 }
 
 fn normalize_max_iterations(value: f64) -> usize {


### PR DESCRIPTION
Fixes #173

## 问题

内置 AI Agent 无法自定义人设/行为规则，用户希望可配置自定义系统提示词。

## 实现方式

运行时管道已现成（`Session::set_system_instruction` → `build_system_prompt` 的 `append_system_instruction` 追加段落），本次只做应用层接线：

- **`AiChatSettings.custom_system_prompt`**（serde default 空串，旧配置零迁移）；`effective_custom_system_prompt()` 统一 trim / 空串归 None / 8000 字符钳制
- **Agent 设置组**新增多行提示词编辑项（Textarea 4~12 行自适应，Change 即存），范式与 SQL 格式化预览框一致；i18n en / zh-CN / zh-HK
- **AgentChatView 接线**：
  - 初始化用设置值种子化首个会话（外部经 `pending_system_instruction` 注入的指令不被覆盖）
  - 新建会话跟随设置最新值
  - 切换历史会话：快照自带指令优先（行为可复现），无指令旧会话回落到设置值
  - 外部显式 `set_system_instruction`（终端侧边栏按连接注入路径）不被设置覆盖
- 语义：自定义提示词**追加在内置基座之后**，工具选择规则、计划纪律等安全边界保持权威；仅作用本地 runtime，ACP 外部 Agent 不适用（文案注明）

## 测试

- `cargo test -p one-core --lib` 652 通过（含新增 3 项：旧配置兼容 / trim 归 None / 超长钳制）
- `ai_chat_view` 新增 3 项 gpui 测试：设置种子化真实发送到运行时 / 外部指令优先 / 切换恢复快照指令，全部通过
- clippy 改动前后对比无新增警告

## 备注

分支包含一个 pin 回退：`bc5de0f9f` 把 gpui-component pin 到 `460f5c50`，该 rev 未推送远端且 `gpui-base` 在其下编译不过（ShapedLine 字段适配未完成），故回退到 `cea6f302`。